### PR TITLE
Fix a deadlock error in the integration tests

### DIFF
--- a/test/integration/setup.js
+++ b/test/integration/setup.js
@@ -39,12 +39,9 @@ function deleteAllTables(database) {
 			return database.raw(query);
 		})
 		.then(result => {
-			return result.rows.map(row => row.tablename);
+			return result.rows.map(row => `DROP TABLE ${row.tablename} CASCADE`).join(';');
 		})
-		.then(tablenames => {
-			return Promise.all(tablenames.map(tablename => {
-				const query = `DROP TABLE ${tablename} CASCADE`;
-				return database.raw(query);
-			}));
+		.then(query => {
+			return database.raw(query);
 		});
 }


### PR DESCRIPTION
Every now and then you'd get a deadlock error when deleting the database
tables in the integration tests. Running a single query rather than
using Promise.all fixes this.
