### PR TITLE
Read API

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -39,7 +39,7 @@
 	"disallowVar": true,
 	"disallowYodaConditions": true,
 
-	"maximumLineLength": 100,
+	"maximumLineLength": 120,
 
 	"requireArrowFunctions": true,
 	"requireBlocksOnNewline": true,

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ env:
 # Services setup
 services:
   - postgresql
+addons:
+  postgresql: '9.2'
 
 # Restrict builds on branches
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,9 @@
 
+# Container version
+# (important for modern PostgreSQL)
+dist: trusty
+sudo: false
+
 # Build matrix
 language: node_js
 matrix:
@@ -8,10 +13,40 @@ matrix:
     - node_js: '6'
       env: LINT=true
 
-    # Run tests
+    # Run tests with varying Node.js and
+    # default PostgreSQL (9.2)
+
     - node_js: '4'
+      env: NODE=4
+
     - node_js: '5'
+      env: NODE=5
+
     - node_js: '6'
+      env: NODE=6
+
+    # Run integration tests with varying
+    # PostgreSQL and default Node.js (6)
+
+    - node_js: '6'
+      env: POSTGRES=9.3
+      addons:
+        postgresql: '9.3'
+
+    - node_js: '6'
+      env: POSTGRES=9.4
+      addons:
+        postgresql: '9.4'
+
+    - node_js: '6'
+      env: POSTGRES=9.5
+      addons:
+        postgresql: '9.5'
+
+    - node_js: '6'
+      env: POSTGRES=9.6
+      addons:
+        postgresql: '9.6'
 
 # Global environment variables
 env:
@@ -35,4 +70,5 @@ before_script:
   - psql -c "CREATE DATABASE pa11y_sidekick_travis" -U postgres
 script:
   - 'if [ $LINT ]; then make verify; fi'
-  - 'if [ ! $LINT ]; then make test; fi'
+  - 'if [ $NODE ]; then make test; fi'
+  - 'if [ $POSTGRES ]; then make test-integration; fi'

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ If you have any feedback, we'd love to hear it! This architecture is not yet set
 
 ## Running locally
 
-This application requires [Node.js] 4+ and [PostgreSQL].
+This application requires [Node.js] 4+ and [PostgreSQL] 9.2+.
 
   1. Install dependencies:
 

--- a/controller/api-v1.js
+++ b/controller/api-v1.js
@@ -57,6 +57,23 @@ module.exports = dashboard => {
 			.catch(next);
 	});
 
+	// Get a site's results
+	app.all('/api/v1/sites/:siteId/results', allow.get, (request, response, next) => {
+		const json = {};
+		model.site.getById(request.params.siteId)
+			.then(site => {
+				if (!site) {
+					throw httpError(404);
+				}
+				return model.result.getAllBySite(site.id);
+			})
+			.then(results => {
+				json.results = results;
+				response.send(json);
+			})
+			.catch(next);
+	});
+
 	// Get a site/URL by ID
 	app.all('/api/v1/sites/:siteId/urls/:urlId', allow.get, (request, response, next) => {
 		const json = {};
@@ -66,6 +83,37 @@ module.exports = dashboard => {
 					throw httpError(404);
 				}
 				json.url = url;
+				response.send(json);
+			})
+			.catch(next);
+	});
+
+	// Get a site/URL results
+	app.all('/api/v1/sites/:siteId/urls/:urlId/results', allow.get, (request, response, next) => {
+		const json = {};
+		model.url.getByIdAndSite(request.params.urlId, request.params.siteId)
+			.then(url => {
+				if (!url) {
+					throw httpError(404);
+				}
+				return model.result.getAllByUrl(request.params.urlId);
+			})
+			.then(results => {
+				json.results = results;
+				response.send(json);
+			})
+			.catch(next);
+	});
+
+	// Get a site/URL/result by ID
+	app.all('/api/v1/sites/:siteId/urls/:urlId/results/:resultId', allow.get, (request, response, next) => {
+		const json = {};
+		model.result.getByIdAndUrlAndSite(request.params.resultId, request.params.urlId, request.params.siteId)
+			.then(result => {
+				if (!result) {
+					throw httpError(404);
+				}
+				json.result = result;
 				response.send(json);
 			})
 			.catch(next);

--- a/controller/api-v1.js
+++ b/controller/api-v1.js
@@ -2,11 +2,13 @@
 
 const allow = require('../middleware/allow');
 const handleErrors = require('../middleware/handle-errors');
+const httpError = require('http-errors');
 const notFound = require('../middleware/not-found');
 const requireUserAgent = require('../middleware/require-user-agent');
 
 module.exports = dashboard => {
 	const app = dashboard.app;
+	const model = dashboard.model;
 
 	app.use('/api/v1', requireUserAgent);
 
@@ -16,29 +18,57 @@ module.exports = dashboard => {
 	});
 
 	// Get all sites
-	app.all('/api/v1/sites', allow.get, (request, response) => {
-		dashboard.model.site.getAll().then(sites => {
-			response.send({sites});
-		});
+	app.all('/api/v1/sites', allow.get, (request, response, next) => {
+		model.site.getAll()
+			.then(sites => {
+				response.send({sites});
+			})
+			.catch(next);
 	});
 
 	// Get a site by ID
 	app.all('/api/v1/sites/:siteId', allow.get, (request, response, next) => {
 		const json = {};
-		dashboard.model.site.getById(request.params.siteId)
+		model.site.getById(request.params.siteId)
 			.then(site => {
 				if (!site) {
-					return next();
+					throw httpError(404);
 				}
 				json.site = site;
-				return dashboard.model.url.getAllBySite(site.id);
+				response.send(json);
+			})
+			.catch(next);
+	});
+
+	// Get a site's URLs
+	app.all('/api/v1/sites/:siteId/urls', allow.get, (request, response, next) => {
+		const json = {};
+		model.site.getById(request.params.siteId)
+			.then(site => {
+				if (!site) {
+					throw httpError(404);
+				}
+				return model.url.getAllBySite(site.id);
 			})
 			.then(urls => {
-				if (json.site) {
-					json.urls = urls;
-					response.send(json);
+				json.urls = urls;
+				response.send(json);
+			})
+			.catch(next);
+	});
+
+	// Get a site/URL by ID
+	app.all('/api/v1/sites/:siteId/urls/:urlId', allow.get, (request, response, next) => {
+		const json = {};
+		model.url.getByIdAndSite(request.params.urlId, request.params.siteId)
+			.then(url => {
+				if (!url) {
+					throw httpError(404);
 				}
-			});
+				json.url = url;
+				response.send(json);
+			})
+			.catch(next);
 	});
 
 	// API 404 handler

--- a/data/migration/20160509205059_setup.js
+++ b/data/migration/20160509205059_setup.js
@@ -12,9 +12,9 @@ exports.up = (database, Promise) => {
 
 				// Sites table columns
 				table.string('id').unique().primary();
+				table.timestamp('createdAt').defaultTo(database.fn.now());
+				table.timestamp('updatedAt').defaultTo(database.fn.now());
 				table.string('name').notNullable();
-				table.timestamp('created_at').defaultTo(database.fn.now());
-				table.timestamp('updated_at').defaultTo(database.fn.now());
 
 			});
 		})
@@ -25,12 +25,32 @@ exports.up = (database, Promise) => {
 				// URLs table columns
 				table.string('id').unique().primary();
 				table.string('site');
+				table.timestamp('createdAt').defaultTo(database.fn.now());
+				table.timestamp('updatedAt').defaultTo(database.fn.now());
 				table.string('name').notNullable();
 				table.string('address').notNullable();
-				table.timestamp('created_at').defaultTo(database.fn.now());
-				table.timestamp('updated_at').defaultTo(database.fn.now());
 
 				// Foreign key contraints
+				table.foreign('site').references('sites.id');
+
+			});
+		})
+		.then(() => {
+			// Create the results table
+			return database.schema.createTable('results', table => {
+
+				// Results table columns
+				table.string('id').unique().primary();
+				table.string('url');
+				table.string('site');
+				table.timestamp('createdAt').defaultTo(database.fn.now());
+				table.integer('errorCount').notNullable().defaultTo(0);
+				table.integer('warningCount').notNullable().defaultTo(0);
+				table.integer('noticeCount').notNullable().defaultTo(0);
+				table.json('messages').notNullable().defaultTo('[]');
+
+				// Foreign key contraints
+				table.foreign('url').references('urls.id');
 				table.foreign('site').references('sites.id');
 
 			});
@@ -39,6 +59,9 @@ exports.up = (database, Promise) => {
 
 exports.down = (database, Promise) => {
 	return Promise.resolve()
+		.then(() => {
+			return database.schema.dropTable('results');
+		})
 		.then(() => {
 			return database.schema.dropTable('urls');
 		})

--- a/data/seed/empty-website.js
+++ b/data/seed/empty-website.js
@@ -1,0 +1,17 @@
+'use strict';
+
+// Note: IDs in here are referenced in the integration
+// tests, so should not be changed.
+exports.seed = (database, Promise) => {
+	const siteId = 's03e_site';
+
+	return Promise.resolve()
+		.then(() => {
+			// Add a site
+			return database('sites').insert({
+				id: siteId,
+				name: 'Empty'
+			});
+		});
+
+};

--- a/data/seed/empty-website.js
+++ b/data/seed/empty-website.js
@@ -1,3 +1,4 @@
+// jscs:disable maximumLineLength
 'use strict';
 
 // Note: IDs in here are referenced in the integration

--- a/data/seed/github-website.js
+++ b/data/seed/github-website.js
@@ -1,3 +1,4 @@
+// jscs:disable maximumLineLength
 'use strict';
 
 // Note: IDs in here are referenced in the integration
@@ -21,6 +22,38 @@ exports.seed = (database, Promise) => {
 					site: siteId,
 					name: 'Home',
 					address: 'https://github.com/'
+				}
+			]);
+		})
+		.then(() => {
+			// Add a bunch of results to the URLs
+			return database('results').insert([
+				{
+					id: 's02g_u01h_r01',
+					url: 's02g_u01h',
+					site: siteId,
+					createdAt: new Date(Date.now()), // now
+					errorCount: 0,
+					warningCount: 1,
+					noticeCount: 1,
+					messages: JSON.stringify([
+						{
+							code: 'WCAG2AA.Principle1.Guideline1_3.1_3_1.H49.B',
+							context: '<b>Hello World!</b>',
+							message: 'Semantic markup should be used to mark emphasised or special text so that it can be programmatically determined.',
+							selector: '#content > b:nth-child(4)',
+							type: 'warning',
+							typeCode: 2
+						},
+						{
+							code: 'WCAG2AA.Principle2.Guideline2_4.2_4_4.H77,H78,H79,H80,H81',
+							context: '<a href="http://example.com/">Hello World!</a>',
+							message: 'Check that the link text combined with programmatically determined link context identifies the purpose of the link.',
+							selector: 'html > body > ul > li:nth-child(2) > a',
+							type: 'notice',
+							typeCode: 3
+						}
+					])
 				}
 			]);
 		});

--- a/data/seed/github-website.js
+++ b/data/seed/github-website.js
@@ -3,36 +3,24 @@
 // Note: IDs in here are referenced in the integration
 // tests, so should not be changed.
 exports.seed = (database, Promise) => {
-	const siteId = 's01p_site';
+	const siteId = 's02g_site';
 
 	return Promise.resolve()
 		.then(() => {
 			// Add a site
 			return database('sites').insert({
 				id: siteId,
-				name: 'Pa11y'
+				name: 'GitHub'
 			});
 		})
 		.then(() => {
 			// Add a bunch of URLs to the site
 			return database('urls').insert([
 				{
-					id: 's01p_u01h',
+					id: 's02g_u01h',
 					site: siteId,
 					name: 'Home',
-					address: 'http://pa11y.github.io/'
-				},
-				{
-					id: 's01p_u02c',
-					site: siteId,
-					name: 'Contact',
-					address: 'http://pa11y.github.io/contact/'
-				},
-				{
-					id: 's01p_u03c',
-					site: siteId,
-					name: 'Contributing',
-					address: 'http://pa11y.github.io/contributing/'
+					address: 'https://github.com/'
 				}
 			]);
 		});

--- a/data/seed/pa11y-website.js
+++ b/data/seed/pa11y-website.js
@@ -1,3 +1,4 @@
+// jscs:disable maximumLineLength
 'use strict';
 
 // Note: IDs in here are referenced in the integration
@@ -33,6 +34,151 @@ exports.seed = (database, Promise) => {
 					site: siteId,
 					name: 'Contributing',
 					address: 'http://pa11y.github.io/contributing/'
+				}
+			]);
+		})
+		.then(() => {
+			// Add a bunch of results to the URLs
+			return database('results').insert([
+				{
+					id: 's01p_u01h_r01',
+					url: 's01p_u01h',
+					site: siteId,
+					createdAt: new Date(Date.now() - 172800000), // 2 days ago
+					errorCount: 2,
+					warningCount: 2,
+					noticeCount: 1,
+					messages: JSON.stringify([
+						{
+							code: 'WCAG2AA.Principle1.Guideline1_1.1_1_1.H30.2',
+							context: '<a href="http://example.com/"><img src="example1.jpg" alt=""/></a>',
+							message: 'Img element is the only content of the link, but is missing alt text. The alt text should describe the purpose of the link.',
+							selector: 'html > body > p:nth-child(1) > a',
+							type: 'error',
+							typeCode: 1
+						},
+						{
+							code: 'WCAG2AA.Principle1.Guideline1_1.1_1_1.H30.2',
+							context: '<a href="http://example.com/"><img src="example2.jpg" alt=""/></a>',
+							message: 'Img element is the only content of the link, but is missing alt text. The alt text should describe the purpose of the link.',
+							selector: 'html > body > p:nth-child(2) > a',
+							type: 'error',
+							typeCode: 1
+						},
+						{
+							code: 'WCAG2AA.Principle1.Guideline1_3.1_3_1.H49.B',
+							context: '<b>Hello World!</b>',
+							message: 'Semantic markup should be used to mark emphasised or special text so that it can be programmatically determined.',
+							selector: '#content > b:nth-child(4)',
+							type: 'warning',
+							typeCode: 2
+						},
+						{
+							code: 'WCAG2AA.Principle1.Guideline1_3.1_3_1.H49.B',
+							context: '<b>This is a result.</b>',
+							message: 'Semantic markup should be used to mark emphasised or special text so that it can be programmatically determined.',
+							selector: '#content > b:nth-child(5)',
+							type: 'warning',
+							typeCode: 2
+						},
+						{
+							code: 'WCAG2AA.Principle2.Guideline2_4.2_4_4.H77,H78,H79,H80,H81',
+							context: '<a href="http://example.com/">Hello World!</a>',
+							message: 'Check that the link text combined with programmatically determined link context identifies the purpose of the link.',
+							selector: 'html > body > ul > li:nth-child(2) > a',
+							type: 'notice',
+							typeCode: 3
+						}
+					])
+				},
+				{
+					id: 's01p_u01h_r02',
+					url: 's01p_u01h',
+					site: siteId,
+					createdAt: new Date(Date.now() - 86400000), // yesterday
+					errorCount: 1,
+					warningCount: 1,
+					noticeCount: 1,
+					messages: JSON.stringify([
+						{
+							code: 'WCAG2AA.Principle1.Guideline1_1.1_1_1.H30.2',
+							context: '<a href="http://example.com/"><img src="example1.jpg" alt=""/></a>',
+							message: 'Img element is the only content of the link, but is missing alt text. The alt text should describe the purpose of the link.',
+							selector: 'html > body > p:nth-child(1) > a',
+							type: 'error',
+							typeCode: 1
+						},
+						{
+							code: 'WCAG2AA.Principle1.Guideline1_3.1_3_1.H49.B',
+							context: '<b>Hello World!</b>',
+							message: 'Semantic markup should be used to mark emphasised or special text so that it can be programmatically determined.',
+							selector: '#content > b:nth-child(4)',
+							type: 'warning',
+							typeCode: 2
+						},
+						{
+							code: 'WCAG2AA.Principle2.Guideline2_4.2_4_4.H77,H78,H79,H80,H81',
+							context: '<a href="http://example.com/">Hello World!</a>',
+							message: 'Check that the link text combined with programmatically determined link context identifies the purpose of the link.',
+							selector: 'html > body > ul > li:nth-child(2) > a',
+							type: 'notice',
+							typeCode: 3
+						}
+					])
+				},
+				{
+					id: 's01p_u01h_r03',
+					url: 's01p_u01h',
+					site: siteId,
+					createdAt: new Date(Date.now()), // now
+					errorCount: 0,
+					warningCount: 1,
+					noticeCount: 1,
+					messages: JSON.stringify([
+						{
+							code: 'WCAG2AA.Principle1.Guideline1_3.1_3_1.H49.B',
+							context: '<b>Hello World!</b>',
+							message: 'Semantic markup should be used to mark emphasised or special text so that it can be programmatically determined.',
+							selector: '#content > b:nth-child(4)',
+							type: 'warning',
+							typeCode: 2
+						},
+						{
+							code: 'WCAG2AA.Principle2.Guideline2_4.2_4_4.H77,H78,H79,H80,H81',
+							context: '<a href="http://example.com/">Hello World!</a>',
+							message: 'Check that the link text combined with programmatically determined link context identifies the purpose of the link.',
+							selector: 'html > body > ul > li:nth-child(2) > a',
+							type: 'notice',
+							typeCode: 3
+						}
+					])
+				},
+				{
+					id: 's01p_u03c_r01',
+					url: 's01p_u03c',
+					site: siteId,
+					createdAt: new Date(Date.now()), // now
+					errorCount: 0,
+					warningCount: 1,
+					noticeCount: 1,
+					messages: JSON.stringify([
+						{
+							code: 'WCAG2AA.Principle1.Guideline1_3.1_3_1.H49.B',
+							context: '<b>Hello World!</b>',
+							message: 'Semantic markup should be used to mark emphasised or special text so that it can be programmatically determined.',
+							selector: '#content > b:nth-child(4)',
+							type: 'warning',
+							typeCode: 2
+						},
+						{
+							code: 'WCAG2AA.Principle2.Guideline2_4.2_4_4.H77,H78,H79,H80,H81',
+							context: '<a href="http://example.com/">Hello World!</a>',
+							message: 'Check that the link text combined with programmatically determined link context identifies the purpose of the link.',
+							selector: 'html > body > ul > li:nth-child(2) > a',
+							type: 'notice',
+							typeCode: 3
+						}
+					])
 				}
 			]);
 		});

--- a/model/result.js
+++ b/model/result.js
@@ -1,0 +1,100 @@
+// jscs:disable disallowDanglingUnderscores
+'use strict';
+
+module.exports = dashboard => {
+	const database = dashboard.database;
+	const table = 'results';
+
+	const model = {
+
+		// Get all results for a URL
+		getAllByUrl(urlId) {
+			return this._rawGetAllByUrl(urlId).then(results => {
+				return results.map(this.prepareForOutput);
+			});
+		},
+
+		// Get all results for a site
+		getAllBySite(siteId) {
+			return this._rawGetAllBySite(siteId).then(results => {
+				return results.map(this.prepareForOutput);
+			});
+		},
+
+		// Get a single result by ID
+		getById(id) {
+			return this._rawGetById(id).then(result => {
+				return (result ? this.prepareForOutput(result) : result);
+			});
+		},
+
+		// Get a single result by ID, URL ID, and site ID
+		getByIdAndUrlAndSite(id, urlId, siteId) {
+			return this._rawGetByIdAndUrlAndSite(id, urlId, siteId).then(result => {
+				return (result ? this.prepareForOutput(result) : result);
+			});
+		},
+
+		// Prepare a result object for output
+		prepareForOutput(result) {
+			result.paths = {
+				api: `/api/v1/sites/${result.site}/urls/${result.url}/results/${result.id}`
+			};
+			return result;
+		},
+
+		// "Raw" methods used to get data that's not
+		// prepared for output to the user
+
+		_rawGetAllByUrl(url) {
+			return database
+				.select('*')
+				.from(table)
+				.where({
+					url
+				})
+				.orderBy('createdAt', 'desc');
+		},
+
+		_rawGetAllBySite(site) {
+			return database
+				.select('*')
+				.from(table)
+				.where({
+					site
+				})
+				.orderBy('createdAt', 'desc');
+		},
+
+		_rawGetById(id) {
+			return database
+				.select('*')
+				.from(table)
+				.where({
+					id
+				})
+				.limit(1)
+				.then(results => {
+					return results[0];
+				});
+		},
+
+		_rawGetByIdAndUrlAndSite(id, url, site) {
+			return database
+				.select('*')
+				.from(table)
+				.where({
+					id,
+					url,
+					site
+				})
+				.limit(1)
+				.then(results => {
+					return results[0];
+				});
+		}
+
+	};
+
+	return model;
+};

--- a/model/site.js
+++ b/model/site.js
@@ -35,6 +35,7 @@ module.exports = dashboard => {
 		_rawGetAll() {
 			return database
 				.select('*')
+				.orderBy('name')
 				.from(table);
 		},
 

--- a/model/site.js
+++ b/model/site.js
@@ -23,6 +23,9 @@ module.exports = dashboard => {
 
 		// Prepare a site object for output
 		prepareForOutput(site) {
+			site.paths = {
+				api: `/api/v1/sites/${site.id}`
+			};
 			return site;
 		},
 
@@ -30,13 +33,22 @@ module.exports = dashboard => {
 		// prepared for output to the user
 
 		_rawGetAll() {
-			return database.select('*').from(table);
+			return database
+				.select('*')
+				.from(table);
 		},
 
 		_rawGetById(id) {
-			return database.select('*').from(table).where({id}).limit(1).then(sites => {
-				return sites[0];
-			});
+			return database
+				.select('*')
+				.from(table)
+				.where({
+					id
+				})
+				.limit(1)
+				.then(sites => {
+					return sites[0];
+				});
 		}
 
 	};

--- a/model/url.js
+++ b/model/url.js
@@ -43,7 +43,10 @@ module.exports = dashboard => {
 			return database
 				.select('*')
 				.from(table)
-				.where({site});
+				.where({
+					site
+				})
+				.orderBy('name');
 		},
 
 		_rawGetById(id) {

--- a/model/url.js
+++ b/model/url.js
@@ -8,8 +8,8 @@ module.exports = dashboard => {
 	const model = {
 
 		// Get all URLs for a site
-		getAllBySite(id) {
-			return this._rawGetAllBySite(id).then(urls => {
+		getAllBySite(siteId) {
+			return this._rawGetAllBySite(siteId).then(urls => {
 				return urls.map(this.prepareForOutput);
 			});
 		},
@@ -21,22 +21,56 @@ module.exports = dashboard => {
 			});
 		},
 
+		// Get a single URL by ID and site ID
+		getByIdAndSite(id, siteId) {
+			return this._rawGetByIdAndSite(id, siteId).then(url => {
+				return (url ? this.prepareForOutput(url) : url);
+			});
+		},
+
 		// Prepare a URL object for output
 		prepareForOutput(url) {
+			url.paths = {
+				api: `/api/v1/sites/${url.site}/urls/${url.id}`
+			};
 			return url;
 		},
 
 		// "Raw" methods used to get data that's not
 		// prepared for output to the user
 
-		_rawGetAllBySite(id) {
-			return database.select('*').from(table).where({site: id});
+		_rawGetAllBySite(site) {
+			return database
+				.select('*')
+				.from(table)
+				.where({site});
 		},
 
 		_rawGetById(id) {
-			return database.select('*').from(table).where({id}).limit(1).then(urls => {
-				return urls[0];
-			});
+			return database
+				.select('*')
+				.from(table)
+				.where({
+					id
+				})
+				.limit(1)
+				.then(urls => {
+					return urls[0];
+				});
+		},
+
+		_rawGetByIdAndSite(id, site) {
+			return database
+				.select('*')
+				.from(table)
+				.where({
+					id,
+					site
+				})
+				.limit(1)
+				.then(urls => {
+					return urls[0];
+				});
 		}
 
 	};

--- a/test/integration/api-v1.js
+++ b/test/integration/api-v1.js
@@ -64,11 +64,12 @@ describe('GET /api/v1/sites', () => {
 	it('responds with all of the sites in the database as an array', done => {
 		dashboard.database.select('*').from('sites')
 			.then(sites => {
-				const jsonifiedSites = JSON.parse(JSON.stringify(sites));
+				const jsonifiedSites = JSON.parse(JSON.stringify(sites))
+					.map(dashboard.model.site.prepareForOutput);
 				request.expect(response => {
 					assert.isObject(response.body);
 					assert.isArray(response.body.sites);
-					assert.greaterThan(response.body.length, 0);
+					assert.greaterThan(response.body.sites.length, 0);
 					assert.deepEqual(response.body.sites, jsonifiedSites);
 				}).end(done);
 			})
@@ -81,14 +82,9 @@ describe('GET /api/v1/sites/:siteId', () => {
 	let request;
 	let siteId;
 
-	beforeEach(done => {
-		dashboard.database.select('*').from('sites')
-			.then(sites => {
-				siteId = sites[0].id;
-				request = agent.get(`/api/v1/sites/${siteId}`);
-				done();
-			})
-			.catch(done);
+	beforeEach(() => {
+		siteId = 's01p_site';
+		request = agent.get(`/api/v1/sites/${siteId}`);
 	});
 
 	it('responds with a 200 status', done => {
@@ -102,7 +98,8 @@ describe('GET /api/v1/sites/:siteId', () => {
 	it('responds with the site as an object', done => {
 		dashboard.database.select('*').from('sites').where({id: siteId})
 			.then(sites => {
-				const jsonifiedSite = JSON.parse(JSON.stringify(sites[0]));
+				const jsonifiedSite = dashboard.model.site
+					.prepareForOutput(JSON.parse(JSON.stringify(sites[0])));
 				request.expect(response => {
 					assert.isObject(response.body);
 					assert.isObject(response.body.site);
@@ -110,6 +107,165 @@ describe('GET /api/v1/sites/:siteId', () => {
 				}).end(done);
 			})
 			.catch(done);
+	});
+
+	describe('when a site with the given ID does not exist', () => {
+
+		beforeEach(() => {
+			siteId = 'notasite';
+			request = agent.get(`/api/v1/sites/${siteId}`);
+		});
+
+		it('responds with a 404 status', done => {
+			request.expect(404).end(done);
+		});
+
+	});
+
+});
+
+describe('GET /api/v1/sites/:siteId/urls', () => {
+	let request;
+	let siteId;
+
+	beforeEach(() => {
+		siteId = 's01p_site';
+		request = agent.get(`/api/v1/sites/${siteId}/urls`);
+	});
+
+	it('responds with a 200 status', done => {
+		request.expect(200).end(done);
+	});
+
+	it('responds with JSON', done => {
+		request.expect('Content-Type', 'application/json; charset=utf-8').end(done);
+	});
+
+	it('responds with all of the urls in the database for the given site as an array', done => {
+		dashboard.database.select('*').from('urls').where({site: siteId})
+			.then(urls => {
+				const jsonifiedUrls = JSON.parse(JSON.stringify(urls))
+					.map(dashboard.model.url.prepareForOutput);
+				request.expect(response => {
+					assert.isObject(response.body);
+					assert.isArray(response.body.urls);
+					assert.greaterThan(response.body.urls.length, 0);
+					assert.deepEqual(response.body.urls, jsonifiedUrls);
+				}).end(done);
+			})
+			.catch(done);
+	});
+
+	describe('when the site has no URLs', () => {
+
+		beforeEach(() => {
+			siteId = 's03e_site';
+			request = agent.get(`/api/v1/sites/${siteId}/urls`);
+		});
+
+		it('responds with a 200 status', done => {
+			request.expect(200).end(done);
+		});
+
+		it('responds with JSON', done => {
+			request.expect('Content-Type', 'application/json; charset=utf-8').end(done);
+		});
+
+		it('responds with an empty array', done => {
+			request.expect(response => {
+				assert.isObject(response.body);
+				assert.isArray(response.body.urls);
+				assert.strictEqual(response.body.urls.length, 0);
+			}).end(done);
+		});
+
+	});
+
+	describe('when a site with the given ID does not exist', () => {
+
+		beforeEach(() => {
+			siteId = 'notasite';
+			request = agent.get(`/api/v1/sites/${siteId}/urls`);
+		});
+
+		it('responds with a 404 status', done => {
+			request.expect(404).end(done);
+		});
+
+	});
+
+});
+
+describe('GET /api/v1/sites/:siteId/urls/:urlId', () => {
+	let request;
+	let siteId;
+	let urlId;
+
+	beforeEach(() => {
+		siteId = 's01p_site';
+		urlId = 's01p_u02c';
+		request = agent.get(`/api/v1/sites/${siteId}/urls/${urlId}`);
+	});
+
+	it('responds with a 200 status', done => {
+		request.expect(200).end(done);
+	});
+
+	it('responds with JSON', done => {
+		request.expect('Content-Type', 'application/json; charset=utf-8').end(done);
+	});
+
+	it('responds with the url as an object', done => {
+		dashboard.database.select('*').from('urls').where({id: urlId})
+			.then(urls => {
+				const jsonifiedUrl = dashboard.model.url
+					.prepareForOutput(JSON.parse(JSON.stringify(urls[0])));
+				request.expect(response => {
+					assert.isObject(response.body);
+					assert.isObject(response.body.url);
+					assert.deepEqual(response.body.url, jsonifiedUrl);
+				}).end(done);
+			})
+			.catch(done);
+	});
+
+	describe('when a site with the given ID does not exist', () => {
+
+		beforeEach(() => {
+			siteId = 'notasite';
+			request = agent.get(`/api/v1/sites/${siteId}/urls/${urlId}`);
+		});
+
+		it('responds with a 404 status', done => {
+			request.expect(404).end(done);
+		});
+
+	});
+
+	describe('when a url with the given ID does not exist', () => {
+
+		beforeEach(() => {
+			urlId = 'notaurl';
+			request = agent.get(`/api/v1/sites/${siteId}/urls/${urlId}`);
+		});
+
+		it('responds with a 404 status', done => {
+			request.expect(404).end(done);
+		});
+
+	});
+
+	describe('when the site ID and url ID are mismatched', () => {
+
+		beforeEach(() => {
+			urlId = 's02g_u01h';
+			request = agent.get(`/api/v1/sites/${siteId}/urls/${urlId}`);
+		});
+
+		it('responds with a 404 status', done => {
+			request.expect(404).end(done);
+		});
+
 	});
 
 });

--- a/test/integration/api-v1.js
+++ b/test/integration/api-v1.js
@@ -62,7 +62,7 @@ describe('GET /api/v1/sites', () => {
 	});
 
 	it('responds with all of the sites in the database as an array', done => {
-		dashboard.database.select('*').from('sites')
+		dashboard.database.select('*').from('sites').orderBy('name')
 			.then(sites => {
 				const jsonifiedSites = JSON.parse(JSON.stringify(sites))
 					.map(dashboard.model.site.prepareForOutput);
@@ -124,6 +124,80 @@ describe('GET /api/v1/sites/:siteId', () => {
 
 });
 
+describe('GET /api/v1/sites/:siteId/results', () => {
+	let request;
+	let siteId;
+
+	beforeEach(() => {
+		siteId = 's01p_site';
+		request = agent.get(`/api/v1/sites/${siteId}/results`);
+	});
+
+	it('responds with a 200 status', done => {
+		request.expect(200).end(done);
+	});
+
+	it('responds with JSON', done => {
+		request.expect('Content-Type', 'application/json; charset=utf-8').end(done);
+	});
+
+	it('responds with all of the results in the database for the given site as an array', done => {
+		dashboard.database.select('*').from('results').orderBy('createdAt', 'desc').where({
+			site: siteId
+		})
+		.then(results => {
+			const jsonifiedResults = JSON.parse(JSON.stringify(results))
+				.map(dashboard.model.result.prepareForOutput);
+			request.expect(response => {
+				assert.isObject(response.body);
+				assert.isArray(response.body.results);
+				assert.greaterThan(response.body.results.length, 0);
+				assert.deepEqual(response.body.results, jsonifiedResults);
+			}).end(done);
+		})
+		.catch(done);
+	});
+
+	describe('when the site has no results', () => {
+
+		beforeEach(() => {
+			siteId = 's03e_site';
+			request = agent.get(`/api/v1/sites/${siteId}/results`);
+		});
+
+		it('responds with a 200 status', done => {
+			request.expect(200).end(done);
+		});
+
+		it('responds with JSON', done => {
+			request.expect('Content-Type', 'application/json; charset=utf-8').end(done);
+		});
+
+		it('responds with an empty array', done => {
+			request.expect(response => {
+				assert.isObject(response.body);
+				assert.isArray(response.body.results);
+				assert.strictEqual(response.body.results.length, 0);
+			}).end(done);
+		});
+
+	});
+
+	describe('when a site with the given ID does not exist', () => {
+
+		beforeEach(() => {
+			siteId = 'notasite';
+			request = agent.get(`/api/v1/sites/${siteId}/results`);
+		});
+
+		it('responds with a 404 status', done => {
+			request.expect(404).end(done);
+		});
+
+	});
+
+});
+
 describe('GET /api/v1/sites/:siteId/urls', () => {
 	let request;
 	let siteId;
@@ -142,7 +216,7 @@ describe('GET /api/v1/sites/:siteId/urls', () => {
 	});
 
 	it('responds with all of the urls in the database for the given site as an array', done => {
-		dashboard.database.select('*').from('urls').where({site: siteId})
+		dashboard.database.select('*').from('urls').where({site: siteId}).orderBy('name')
 			.then(urls => {
 				const jsonifiedUrls = JSON.parse(JSON.stringify(urls))
 					.map(dashboard.model.url.prepareForOutput);
@@ -260,6 +334,198 @@ describe('GET /api/v1/sites/:siteId/urls/:urlId', () => {
 		beforeEach(() => {
 			urlId = 's02g_u01h';
 			request = agent.get(`/api/v1/sites/${siteId}/urls/${urlId}`);
+		});
+
+		it('responds with a 404 status', done => {
+			request.expect(404).end(done);
+		});
+
+	});
+
+});
+
+describe('GET /api/v1/sites/:siteId/urls/:urlId/results', () => {
+	let request;
+	let siteId;
+	let urlId;
+
+	beforeEach(() => {
+		siteId = 's01p_site';
+		urlId = 's01p_u01h';
+		request = agent.get(`/api/v1/sites/${siteId}/urls/${urlId}/results`);
+	});
+
+	it('responds with a 200 status', done => {
+		request.expect(200).end(done);
+	});
+
+	it('responds with JSON', done => {
+		request.expect('Content-Type', 'application/json; charset=utf-8').end(done);
+	});
+
+	it('responds with all of the results in the database for the given site/url as an array', done => {
+		dashboard.database.select('*').from('results').orderBy('createdAt', 'desc').where({
+			url: urlId,
+			site: siteId
+		})
+		.then(results => {
+			const jsonifiedResults = JSON.parse(JSON.stringify(results))
+				.map(dashboard.model.result.prepareForOutput);
+			request.expect(response => {
+				assert.isObject(response.body);
+				assert.isArray(response.body.results);
+				assert.greaterThan(response.body.results.length, 0);
+				assert.deepEqual(response.body.results, jsonifiedResults);
+			}).end(done);
+		})
+		.catch(done);
+	});
+
+	describe('when the URL has no results', () => {
+
+		beforeEach(() => {
+			urlId = 's01p_u02c';
+			request = agent.get(`/api/v1/sites/${siteId}/urls/${urlId}/results`);
+		});
+
+		it('responds with a 200 status', done => {
+			request.expect(200).end(done);
+		});
+
+		it('responds with JSON', done => {
+			request.expect('Content-Type', 'application/json; charset=utf-8').end(done);
+		});
+
+		it('responds with an empty array', done => {
+			request.expect(response => {
+				assert.isObject(response.body);
+				assert.isArray(response.body.results);
+				assert.strictEqual(response.body.results.length, 0);
+			}).end(done);
+		});
+
+	});
+
+	describe('when a site with the given ID does not exist', () => {
+
+		beforeEach(() => {
+			siteId = 'notasite';
+			request = agent.get(`/api/v1/sites/${siteId}/urls/${urlId}/results`);
+		});
+
+		it('responds with a 404 status', done => {
+			request.expect(404).end(done);
+		});
+
+	});
+
+	describe('when a url with the given ID does not exist', () => {
+
+		beforeEach(() => {
+			urlId = 'notaurl';
+			request = agent.get(`/api/v1/sites/${siteId}/urls/${urlId}/results`);
+		});
+
+		it('responds with a 404 status', done => {
+			request.expect(404).end(done);
+		});
+
+	});
+
+	describe('when the site ID and url ID are mismatched', () => {
+
+		beforeEach(() => {
+			urlId = 's02g_u01h';
+			request = agent.get(`/api/v1/sites/${siteId}/urls/${urlId}/results`);
+		});
+
+		it('responds with a 404 status', done => {
+			request.expect(404).end(done);
+		});
+
+	});
+
+});
+
+describe('GET /api/v1/sites/:siteId/urls/:urlId/results/:resultId', () => {
+	let request;
+	let siteId;
+	let urlId;
+	let resultId;
+
+	beforeEach(() => {
+		siteId = 's01p_site';
+		urlId = 's01p_u01h';
+		resultId = 's01p_u01h_r01';
+		request = agent.get(`/api/v1/sites/${siteId}/urls/${urlId}/results/${resultId}`);
+	});
+
+	it('responds with a 200 status', done => {
+		request.expect(200).end(done);
+	});
+
+	it('responds with JSON', done => {
+		request.expect('Content-Type', 'application/json; charset=utf-8').end(done);
+	});
+
+	it('responds with the result as an object', done => {
+		dashboard.database.select('*').from('results').where({id: resultId})
+			.then(results => {
+				const jsonifiedResult = dashboard.model.result
+					.prepareForOutput(JSON.parse(JSON.stringify(results[0])));
+				request.expect(response => {
+					assert.isObject(response.body);
+					assert.isObject(response.body.result);
+					assert.deepEqual(response.body.result, jsonifiedResult);
+				}).end(done);
+			})
+			.catch(done);
+	});
+
+	describe('when a site with the given ID does not exist', () => {
+
+		beforeEach(() => {
+			siteId = 'notasite';
+			request = agent.get(`/api/v1/sites/${siteId}/urls/${urlId}/results/${resultId}`);
+		});
+
+		it('responds with a 404 status', done => {
+			request.expect(404).end(done);
+		});
+
+	});
+
+	describe('when a url with the given ID does not exist', () => {
+
+		beforeEach(() => {
+			urlId = 'notaurl';
+			request = agent.get(`/api/v1/sites/${siteId}/urls/${urlId}/results/${resultId}`);
+		});
+
+		it('responds with a 404 status', done => {
+			request.expect(404).end(done);
+		});
+
+	});
+
+	describe('when a result with the given ID does not exist', () => {
+
+		beforeEach(() => {
+			resultId = 'notaresult';
+			request = agent.get(`/api/v1/sites/${siteId}/urls/${urlId}/results/${resultId}`);
+		});
+
+		it('responds with a 404 status', done => {
+			request.expect(404).end(done);
+		});
+
+	});
+
+	describe('when the site ID, url ID, and result ID are mismatched', () => {
+
+		beforeEach(() => {
+			urlId = 's02g_u01h';
+			request = agent.get(`/api/v1/sites/${siteId}/urls/${urlId}/results/${resultId}`);
 		});
 
 		it('responds with a 404 status', done => {

--- a/view/api-v1.dust
+++ b/view/api-v1.dust
@@ -6,43 +6,172 @@
 
 {<content}
 
-	<h1>{appName} API</h1>
-	<p>
-		This is the documentation for the {appName} API version 1.
-	</p>
+<h1>{appName} API</h1>
+<p>
+	This is the documentation for the {appName} API version 1.
+</p>
+<ul>
+	<li><a href="#endpoints">Endpoints</a></li>
+	<li><a href="#entities">Entities</a></li>
+</ul>
 
-	<h2><code>GET /api/v1/sites</code></h2>
 
-	<p>
-		Get a list of all sites as a JSON array.
-	</p>
+<h2 id="endpoints">Endpoints</h2>
 
-	<pre>{`{
+
+<h3><code>GET /api/v1/sites</code></h3>
+
+<p>
+	Get a list of all <a href="#entities-site">sites</a> as a JSON array.
+</p>
+
+<pre>{`{
 	sites: [
 		{
-			// site object
+			// site entity
 		},
 		{
-			// site object
+			// site entity
 		}
 	]
 }`}</pre>
 
-	<h2><code>GET /api/v1/sites/<var>:id</var></code></h2>
 
-	<p>
-		Get a single site as a JSON object.
-	</p>
+<h3><code>GET /api/v1/sites/<var>:siteId</var></code></h3>
 
-	<pre>{`{
+<p>
+	Get a single <a href="#entities-site">site</a> as a JSON object.
+</p>
+
+<pre>{`{
 	site: {
-		// site object
-		urls: [
-			{
-				// url object
-			}
-		]
+		// site entity
 	}
+}`}</pre>
+
+
+<h3><code>GET /api/v1/sites/<var>:siteId</var>/results</code></h3>
+
+<p>
+	Get a list of all site <a href="#entities-result">results</a> as a JSON array.
+</p>
+
+<pre>{`{
+	results: [
+		{
+			// result entity
+		},
+		{
+			// result entity
+		}
+	]
+}`}</pre>
+
+
+<h3><code>GET /api/v1/sites/<var>:siteId</var>/urls</code></h3>
+
+<p>
+	Get a list of all site <a href="#entities-url">URLs</a> as a JSON array.
+</p>
+
+<pre>{`{
+	urls: [
+		{
+			// url entity
+		},
+		{
+			// url entity
+		}
+	]
+}`}</pre>
+
+
+<h3><code>GET /api/v1/sites/<var>:siteId</var>/urls/<var>:urlId</var></code></h3>
+
+<p>
+	Get a single <a href="#entities-url">URL</a> as a JSON object.
+</p>
+
+<pre>{`{
+	url: {
+		// url entity
+	}
+}`}</pre>
+
+
+<h3><code>GET /api/v1/sites/<var>:siteId</var>/urls/<var>:urlId</var>/results</code></h3>
+
+<p>
+	Get a list of all URL <a href="#entities-result">results</a> as a JSON array.
+</p>
+
+<pre>{`{
+	results: [
+		{
+			// result entity
+		},
+		{
+			// result entity
+		}
+	]
+}`}</pre>
+
+
+<h3><code>GET /api/v1/sites/<var>:siteId</var>/urls/<var>:urlId</var>/results/<var>:resultId</var></code></h3>
+
+<p>
+	Get a single <a href="#entities-result">result</a> as a JSON object.
+</p>
+
+<pre>{`{
+	result: {
+		// result entity
+	}
+}`}</pre>
+
+
+<h2 id="entities">Entities</h2>
+
+
+<h3 id="entities-site">Site entity</h3>
+
+<p>A site is a collection of URLs, and has the following properties:</p>
+
+<pre>{`{
+	id: String, // Unique ID
+	createdAt: String, // ISO-formatted date/time
+	updatedAt: String, // ISO-formatted date/time
+	name: String // The human-readable name of the site
+}`}</pre>
+
+
+<h3 id="entities-url">URL entity</h3>
+
+<p>A URL represents a URL in a site as well as a collection of results, and has the following properties:</p>
+
+<pre>{`{
+	id: String, // Unique ID
+	site: String, // Unique ID of the site this URL belongs to
+	createdAt: String, // ISO-formatted date/time
+	updatedAt: String, // ISO-formatted date/time
+	name: String, // The human-readable name of the URL
+	address: String // The actual URL address
+}`}</pre>
+
+
+<h3 id="entities-result">Result entity</h3>
+
+<p>A result represents a single run of Pa11y against a specific URL, and has the following properties:</p>
+
+<pre>{`{
+	id: String, // Unique ID
+	url: String, // Unique ID of the URL this result belongs to
+	site: String, // Unique ID of the site this result belongs to
+	createdAt: String, // ISO-formatted date/time
+	errorCount: Number, // The number of errors in this result set
+	warningCount: Number, // The number of warnings in this result set
+	noticeCount: Number, // The number of notices in this result set
+	messages: Array // An array of Pa11y result messages
 }`}</pre>
 
 {/content}

--- a/view/index.dust
+++ b/view/index.dust
@@ -23,5 +23,8 @@
 		<li>
 			<a href="https://github.com/pa11y/sidekick/blob/master/ARCHITECTURE.md">Architecture Guide</a>
 		</li>
+		<li>
+			<a href="/api/v1">API Documentation</a>
+		</li>
 	</ul>
 {/content}


### PR DESCRIPTION
This completes a first version of the read API for Sidekick. I've added a few of you as reviewers, but feel free to not – just wanted to let you know that this was done :)

The following endpoints have been added/completed, and there's a migration and seed data ready for manual testing if you fancy it:

```
GET /api/v1
GET /api/v1/sites
GET /api/v1/sites/:siteId
GET /api/v1/sites/:siteId/results
GET /api/v1/sites/:siteId/urls
GET /api/v1/sites/:siteId/urls/:urlId
GET /api/v1/sites/:siteId/urls/:urlId/results
GET /api/v1/sites/:siteId/urls/:urlId/results/:resultId
```

Running locally should be achievable by following the README instructions (let me know if it's not), and there are pretty extensive integration tests for each of the endpoints in the API.