### PR TITLE
Add Pa11y config to sites and URLs

### DIFF
--- a/data/migration/20160509205059_setup.js
+++ b/data/migration/20160509205059_setup.js
@@ -15,6 +15,7 @@ exports.up = (database, Promise) => {
 				table.timestamp('createdAt').defaultTo(database.fn.now());
 				table.timestamp('updatedAt').defaultTo(database.fn.now());
 				table.string('name').notNullable();
+				table.json('pa11yConfig').notNullable().defaultTo('{}');
 
 			});
 		})
@@ -29,6 +30,7 @@ exports.up = (database, Promise) => {
 				table.timestamp('updatedAt').defaultTo(database.fn.now());
 				table.string('name').notNullable();
 				table.string('address').notNullable();
+				table.json('pa11yConfig').notNullable().defaultTo('{}');
 
 				// Foreign key contraints
 				table.foreign('site').references('sites.id');

--- a/model/site.js
+++ b/model/site.js
@@ -55,13 +55,27 @@ module.exports = dashboard => {
 				if (!data.name.trim()) {
 					throw new Error('Site name cannot be empty');
 				}
+				if (
+					data.pa11yConfig !== undefined &&
+					(
+						typeof data.pa11yConfig !== 'object' ||
+						Array.isArray(data.pa11yConfig) ||
+						data.pa11yConfig === null
+					)
+				) {
+					throw new Error('Site Pa11y config should be an object');
+				}
 			} catch (error) {
 				error.isValidationError = true;
 				return Promise.reject(error);
 			}
-			return Promise.resolve({
+			const cleanData = {
 				name: data.name.trim()
-			});
+			};
+			if (data.pa11yConfig) {
+				cleanData.pa11yConfig = JSON.stringify(data.pa11yConfig);
+			}
+			return Promise.resolve(cleanData);
 		},
 
 		// Prepare a site object for output

--- a/model/url.js
+++ b/model/url.js
@@ -73,15 +73,29 @@ module.exports = dashboard => {
 				if (!data.address.trim()) {
 					throw new Error('URL address cannot be empty');
 				}
+				if (
+					data.pa11yConfig !== undefined &&
+					(
+						typeof data.pa11yConfig !== 'object' ||
+						Array.isArray(data.pa11yConfig) ||
+						data.pa11yConfig === null
+					)
+				) {
+					throw new Error('URL Pa11y config should be an object');
+				}
 			} catch (error) {
 				error.isValidationError = true;
 				return Promise.reject(error);
 			}
-			return Promise.resolve({
+			const cleanData = {
 				site: data.site,
 				name: data.name.trim(),
 				address: data.address.trim()
-			});
+			};
+			if (data.pa11yConfig) {
+				cleanData.pa11yConfig = JSON.stringify(data.pa11yConfig);
+			}
+			return Promise.resolve(cleanData);
 		},
 
 		// Prepare a URL object for output

--- a/test/integration/api-v1.js
+++ b/test/integration/api-v1.js
@@ -93,6 +93,40 @@ describe('POST /api/v1/sites', () => {
 		}).end(done);
 	});
 
+	describe('when the POST data includes Pa11y config', () => {
+
+		beforeEach(() => {
+			testSite.pa11yConfig = {
+				foo: 'bar'
+			};
+			request = agent
+				.post('/api/v1/sites')
+				.set('Content-Type', 'application/json')
+				.send(testSite);
+		});
+
+		it('responds with a 201 status', done => {
+			request.expect(201).end(done);
+		});
+
+		it('creates a site in the database', done => {
+			let response;
+			request.expect(res => response = res).end(() => {
+				const siteId = response.headers.location.match(/\/([a-zA-Z0-9_-]+)$/)[1];
+				dashboard.database.select('*').from('sites').where({id: siteId})
+					.then(sites => {
+						assert.strictEqual(sites.length, 1);
+						assert.deepEqual(sites[0].pa11yConfig, {
+							foo: 'bar'
+						});
+						done();
+					})
+					.catch(done);
+			});
+		});
+
+	});
+
 	describe('when the POST data is invalid', () => {
 
 		beforeEach(() => {
@@ -329,6 +363,38 @@ describe('PATCH /api/v1/sites/:siteId', () => {
 		}).end(done);
 	});
 
+	describe('when the POST data includes Pa11y config', () => {
+
+		beforeEach(() => {
+			testEdits.pa11yConfig = {
+				foo: 'bar'
+			};
+			request = agent
+				.patch(`/api/v1/sites/${siteId}`)
+				.set('Content-Type', 'application/json')
+				.send(testEdits);
+		});
+
+		it('responds with a 200 status', done => {
+			request.expect(200).end(done);
+		});
+
+		it('updates the site in the database', done => {
+			request.end(() => {
+				dashboard.database.select('*').from('sites').where({id: siteId})
+					.then(sites => {
+						assert.strictEqual(sites.length, 1);
+						assert.deepEqual(sites[0].pa11yConfig, {
+							foo: 'bar'
+						});
+						done();
+					})
+					.catch(done);
+			});
+		});
+
+	});
+
 	describe('when a site with the given ID does not exist', () => {
 
 		beforeEach(() => {
@@ -549,7 +615,7 @@ describe('POST /api/v1/sites/:siteId/urls', () => {
 		request.expect('Location', /^\/api\/v1\/sites\/[a-zA-Z0-9_-]+\/urls\/[a-zA-Z0-9_-]+$/).end(done);
 	});
 
-	it('creates a site in the database', done => {
+	it('creates a URL in the database', done => {
 		let response;
 		request.expect(res => response = res).end(() => {
 			const urlId = response.headers.location.match(/\/([a-zA-Z0-9_-]+)$/)[1];
@@ -570,6 +636,40 @@ describe('POST /api/v1/sites/:siteId/urls', () => {
 			assert.isObject(response.body);
 			assert.deepEqual(response.body, {});
 		}).end(done);
+	});
+
+	describe('when the POST data includes Pa11y config', () => {
+
+		beforeEach(() => {
+			testUrl.pa11yConfig = {
+				foo: 'bar'
+			};
+			request = agent
+				.post(`/api/v1/sites/${siteId}/urls`)
+				.set('Content-Type', 'application/json')
+				.send(testUrl);
+		});
+
+		it('responds with a 201 status', done => {
+			request.expect(201).end(done);
+		});
+
+		it('creates a URL in the database', done => {
+			let response;
+			request.expect(res => response = res).end(() => {
+				const urlId = response.headers.location.match(/\/([a-zA-Z0-9_-]+)$/)[1];
+				dashboard.database.select('*').from('urls').where({id: urlId})
+					.then(urls => {
+						assert.strictEqual(urls.length, 1);
+						assert.deepEqual(urls[0].pa11yConfig, {
+							foo: 'bar'
+						});
+						done();
+					})
+					.catch(done);
+			});
+		});
+
 	});
 
 	describe('when the POST data is invalid', () => {
@@ -934,6 +1034,38 @@ describe('PATCH /api/v1/sites/:siteId/urls/:urlId', () => {
 			assert.isObject(response.body);
 			assert.deepEqual(response.body, {});
 		}).end(done);
+	});
+
+	describe('when the POST data includes Pa11y config', () => {
+
+		beforeEach(() => {
+			testEdits.pa11yConfig = {
+				foo: 'bar'
+			};
+			request = agent
+				.patch(`/api/v1/sites/${siteId}/urls/${urlId}`)
+				.set('Content-Type', 'application/json')
+				.send(testEdits);
+		});
+
+		it('responds with a 200 status', done => {
+			request.expect(200).end(done);
+		});
+
+		it('updates the URL in the database', done => {
+			request.end(() => {
+				dashboard.database.select('*').from('urls').where({id: urlId})
+					.then(urls => {
+						assert.strictEqual(urls.length, 1);
+						assert.deepEqual(urls[0].pa11yConfig, {
+							foo: 'bar'
+						});
+						done();
+					})
+					.catch(done);
+			});
+		});
+
 	});
 
 	describe('when the POST data is invalid', () => {


### PR DESCRIPTION
This adds a pa11yConfig JSON field to the tables for sites and URLs.
This JSON is freeform so that we don't have to do work later when new
functionality is added into Pa11y.