### PR TITLE
Add the ability to store settings in the database

### DIFF
--- a/data/migration/20160509205059_setup.js
+++ b/data/migration/20160509205059_setup.js
@@ -65,7 +65,7 @@ exports.up = (database, Promise) => {
 				table.string('id').unique().primary();
 				table.timestamp('createdAt').defaultTo(database.fn.now());
 				table.timestamp('updatedAt').defaultTo(database.fn.now());
-				table.string('username').notNullable().unique();
+				table.string('email').notNullable().unique();
 				table.string('password').notNullable();
 				table.string('apiKey').notNullable().unique();
 				table.boolean('allowRead').notNullable().defaultTo(true);

--- a/data/migration/20160509205059_setup.js
+++ b/data/migration/20160509205059_setup.js
@@ -7,6 +7,16 @@
 exports.up = (database, Promise) => {
 	return Promise.resolve()
 		.then(() => {
+			// Create the settings table
+			return database.schema.createTable('settings', table => {
+
+				// Settings table columns
+				table.string('id').unique().primary();
+				table.json('data').notNullable().defaultTo('{}');
+
+			});
+		})
+		.then(() => {
 			// Create the sites table
 			return database.schema.createTable('sites', table => {
 
@@ -79,6 +89,9 @@ exports.up = (database, Promise) => {
 
 exports.down = (database, Promise) => {
 	return Promise.resolve()
+		.then(() => {
+			return database.schema.dropTable('settings');
+		})
 		.then(() => {
 			return database.schema.dropTable('users');
 		})

--- a/data/seed/settings.js
+++ b/data/seed/settings.js
@@ -1,0 +1,14 @@
+/* eslint max-len: 'off' */
+'use strict';
+
+exports.seed = (database, Promise) => {
+	return Promise.resolve().then(() => {
+		// Add settings to the site
+		return database('settings').insert({
+			id: 'xxxxxx',
+			data: {
+				// nothing here yet
+			}
+		});
+	});
+};

--- a/data/seed/users.js
+++ b/data/seed/users.js
@@ -9,7 +9,7 @@ exports.seed = (database, Promise) => {
 		return database('users').insert([
 			{
 				id: 'user_01',
-				username: 'admin',
+				email: 'admin@example.com',
 				password: 'user_01_pw',
 				apiKey: 'user_01_key',
 				allowRead: true,
@@ -19,7 +19,7 @@ exports.seed = (database, Promise) => {
 			},
 			{
 				id: 'user_02',
-				username: 'default',
+				email: 'default@example.com',
 				password: '',
 				apiKey: '',
 				allowRead: true,
@@ -29,7 +29,7 @@ exports.seed = (database, Promise) => {
 			},
 			{
 				id: 'user_03',
-				username: 'write',
+				email: 'write@example.com',
 				password: 'user_03_pw',
 				apiKey: 'user_03_key',
 				allowRead: true,
@@ -39,7 +39,7 @@ exports.seed = (database, Promise) => {
 			},
 			{
 				id: 'user_04',
-				username: 'delete',
+				email: 'delete@example.com',
 				password: 'user_04_pw',
 				apiKey: 'user_04_key',
 				allowRead: true,

--- a/lib/sidekick.js
+++ b/lib/sidekick.js
@@ -105,7 +105,8 @@ function sidekick(options) {
 		environment: options.environment,
 		log: options.log,
 		options,
-		server: null
+		server: null,
+		settings: {}
 	};
 
 	// These properties are important, as is the call
@@ -142,7 +143,10 @@ function sidekick(options) {
 	// migration scripts) we only want to set it up so
 	// we can make changes to the database
 	if (options.start) {
-		return promiseToStart(dashboard);
+		return dashboard.model.settings.get().then(settings => {
+			dashboard.settings = settings;
+			return promiseToStart(dashboard);
+		});
 	}
 	return Promise.resolve(dashboard);
 }

--- a/model/settings.js
+++ b/model/settings.js
@@ -1,0 +1,24 @@
+/* eslint no-underscore-dangle: 'off' */
+'use strict';
+
+module.exports = dashboard => {
+	const database = dashboard.database;
+	const table = 'settings';
+
+	const model = {
+
+		// Get the settings
+		get() {
+			return database
+				.select('data')
+				.from(table)
+				.limit(1)
+				.then(settings => {
+					return (settings[0] ? settings[0].data : {});
+				});
+		}
+
+	};
+
+	return model;
+};


### PR DESCRIPTION
This will be used to keep track of important info in Sidekick. E.g:

  - Whether the "setup" step has been completed
  - The IDs of the special "super admin" and "unauthenticated" users
  - Any other configurations that we may want to expose in the UI later