### PR TITLE
Add a setup step

### DIFF
--- a/controller/front-end/index.js
+++ b/controller/front-end/index.js
@@ -1,0 +1,25 @@
+'use strict';
+
+module.exports = dashboard => {
+	const app = dashboard.app;
+	const model = dashboard.model;
+
+	// Home page
+	app.get('/', (request, response, next) => {
+
+		// If the site hasn't been set up, switch
+		// to the next matching route – setup
+		if (!dashboard.settings.setupComplete) {
+			return next();
+		}
+
+		// Render the home page
+		model.site.getAll()
+			.then(sites => {
+				response.locals.sites = sites;
+				response.render('index');
+			})
+			.catch(next);
+	});
+
+};

--- a/controller/front-end/main.js
+++ b/controller/front-end/main.js
@@ -6,16 +6,6 @@ module.exports = dashboard => {
 	const app = dashboard.app;
 	const model = dashboard.model;
 
-	// Home page
-	app.get('/', (request, response, next) => {
-		model.site.getAll()
-			.then(sites => {
-				response.locals.sites = sites;
-				response.render('index');
-			})
-			.catch(next);
-	});
-
 	// Site page
 	app.get('/sites/:siteId', (request, response, next) => {
 		model.site.getById(request.params.siteId)

--- a/controller/front-end/setup.js
+++ b/controller/front-end/setup.js
@@ -1,0 +1,80 @@
+'use strict';
+
+const bodyParser = require('body-parser');
+
+module.exports = dashboard => {
+	const app = dashboard.app;
+	const model = dashboard.model;
+	const parseFormBody = bodyParser.urlencoded({
+		extended: false
+	});
+
+	// Setup page
+	app.get('/', (request, response, next) => {
+
+		// If the site has been set up, switch
+		// to the next matching route – home
+		if (dashboard.settings.setupComplete) {
+			return next();
+		}
+
+		// Render the setup page
+		response.render('setup', {
+			formValues: {
+				'default-access-read': true
+			}
+		});
+	});
+
+	// Setup page form post
+	app.post('/', parseFormBody, (request, response, next) => {
+
+		// If the site has been set up, switch
+		// to the next matching route – home
+		if (dashboard.settings.setupComplete) {
+			return next();
+		}
+
+		// Create the admin user
+		const adminUser = {
+			email: request.body['admin-email'],
+			password: request.body['admin-password'],
+			allowRead: true,
+			allowWrite: true,
+			allowDelete: true,
+			allowAdmin: true
+		};
+		model.user.create(adminUser)
+			.then(superAdminId => {
+				// Update all of the settings
+				dashboard.settings.superAdminId = superAdminId;
+				dashboard.settings.defaultPermissions = {
+					allowRead: Boolean(request.body['default-access-read']),
+					allowWrite: Boolean(request.body['default-access-write']),
+					allowDelete: Boolean(request.body['default-access-delete']),
+					allowAdmin: Boolean(request.body['default-access-admin'])
+				};
+
+				// Mark setup as complete
+				dashboard.settings.setupComplete = true;
+			})
+			.then(() => {
+				// Save the settings
+				return model.settings.edit(dashboard.settings);
+			})
+			.then(() => {
+				response.redirect('/');
+			})
+			.catch(error => {
+				if (!error.isValidationError) {
+					return next(error);
+				}
+				response.render('setup', {
+					error: error,
+					formValues: request.body
+				});
+			});
+
+	});
+
+};

--- a/model/settings.js
+++ b/model/settings.js
@@ -1,6 +1,8 @@
 /* eslint no-underscore-dangle: 'off' */
 'use strict';
 
+const shortid = require('shortid');
+
 module.exports = dashboard => {
 	const database = dashboard.database;
 	const table = 'settings';
@@ -15,6 +17,30 @@ module.exports = dashboard => {
 				.limit(1)
 				.then(settings => {
 					return (settings[0] ? settings[0].data : {});
+				});
+		},
+
+		// Edit the settings
+		edit(data) {
+			data = JSON.stringify(data);
+			return database
+				.select('id')
+				.from(table)
+				.limit(1)
+				.then(results => {
+					return (results[0] ? results[0].id : null);
+				})
+				.then(id => {
+					if (id) {
+						return database(table).where({id}).update({
+							data
+						});
+					} else {
+						return database(table).insert({
+							id: shortid.generate(),
+							data
+						});
+					}
 				});
 		}
 

--- a/model/user.js
+++ b/model/user.js
@@ -1,6 +1,10 @@
 /* eslint no-underscore-dangle: 'off' */
 'use strict';
 
+const bcrypt = require('bcrypt');
+const shortid = require('shortid');
+const uuid = require('uuid/v4');
+
 module.exports = dashboard => {
 	const database = dashboard.database;
 	const table = 'users';
@@ -19,6 +23,85 @@ module.exports = dashboard => {
 			return this._rawGetById(id).then(user => {
 				return (user ? this.prepareForOutput(user) : user);
 			});
+		},
+
+		// Create a user (resolving with the new ID)
+		create(data) {
+			return this.cleanInput(data)
+				.then(cleanData => {
+					return this.hashPassword(cleanData.password).then(hash => {
+						cleanData.password = hash;
+						return cleanData;
+					});
+				})
+				.then(cleanData => {
+					cleanData.id = shortid.generate();
+					cleanData.apiKey = uuid();
+					cleanData.createdAt = cleanData.updatedAt = new Date();
+					return this._rawCreate(cleanData);
+				});
+		},
+
+		// Hash a user password
+		hashPassword(password) {
+			const saltRounds = 15;
+			return bcrypt.hash(password, saltRounds);
+		},
+
+		// Check a user password
+		checkPassword(password, hash) {
+			return bcrypt.compare(password, hash);
+		},
+
+		// Validate/sanitize user data input
+		cleanInput(data) {
+			try {
+				if (typeof data !== 'object' || Array.isArray(data) || data === null) {
+					throw new Error('User should be an object');
+				}
+				if (data.id) {
+					throw new Error('User ID cannot be set manually');
+				}
+				if (typeof data.email !== 'string' || !/^.+@.+$/.test(data.email)) {
+					throw new Error('User email should be a valid email address');
+				}
+
+				// TODO ensure it's a good password
+				if (typeof data.password !== 'string') {
+					throw new Error('User password should be a string');
+				}
+				if (!data.password.trim()) {
+					throw new Error('User password cannot be empty');
+				}
+
+				if (data.apiKey) {
+					throw new Error('User API key cannot be set manually');
+				}
+				if (typeof data.allowRead !== 'boolean') {
+					throw new Error('User read permission should be a boolean');
+				}
+				if (typeof data.allowWrite !== 'boolean') {
+					throw new Error('User write permission should be a boolean');
+				}
+				if (typeof data.allowDelete !== 'boolean') {
+					throw new Error('User delete permission should be a boolean');
+				}
+				if (typeof data.allowAdmin !== 'boolean') {
+					throw new Error('User admin permission should be a boolean');
+				}
+			} catch (error) {
+				error.isValidationError = true;
+				return Promise.reject(error);
+			}
+			const cleanData = {
+				email: data.email.trim(),
+				password: data.password.trim(),
+				allowRead: data.allowRead,
+				allowWrite: data.allowWrite,
+				allowDelete: data.allowDelete,
+				allowAdmin: data.allowAdmin
+			};
+			return Promise.resolve(cleanData);
 		},
 
 		// Prepare a user object for output
@@ -51,6 +134,15 @@ module.exports = dashboard => {
 				.limit(1)
 				.then(users => {
 					return users[0];
+				});
+		},
+
+		_rawCreate(data) {
+			return database(table)
+				.returning('id')
+				.insert(data)
+				.then(ids => {
+					return ids[0];
 				});
 		}
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "adaro": "^1.0.4",
+    "bcrypt": "^1.0.2",
     "body-parser": "^1.17.0",
     "compression": "^1.6.2",
     "dotenv": "^2.0.0",
@@ -34,6 +35,7 @@
     "resave-browserify": "^1.0.2",
     "resave-sass": "^1.0.2",
     "shortid": "^2.2.6",
+    "uuid": "^3.0.1",
     "winston": "^2.3.1"
   },
   "devDependencies": {

--- a/view/setup.dust
+++ b/view/setup.dust
@@ -64,7 +64,7 @@
 		</fieldset>
 
 		<p>
-			All done? <input type="submit" value="Setup {appName}"/>
+			All done? <input type="submit" value="Complete setup"/>
 		</p>
 
 	</form>

--- a/view/setup.dust
+++ b/view/setup.dust
@@ -1,0 +1,72 @@
+{>"layout/default"/}
+
+{<title}
+	Setup - {appName}
+{/title}
+
+{<content}
+
+	<h1>Setup</h1>
+
+	<p>
+		Welcome to the {appName} setup. We just need to know a few things before you can start{~s}
+		using the dashboard and testing your sites.
+	</p>
+
+	<form action="/" method="post">
+
+		{?error}
+			<output name="error" class="form-error">
+				There was an error setting up {appName}: {error.message}
+			</output>
+		{/error}
+
+		<fieldset>
+			<legend>Users</legend>
+			<p>
+				First we'll need to set you up as a <i>super</i> admin (yes that's as cool as it sounds).{~s}
+				This will ensure that you always have admin access.
+			</p>
+			<div>
+				<label for="setup-admin-email">Email Address</label>
+				<input id="setup-admin-email" type="email" name="admin-email" value="{formValues.admin-email}"/>
+			</div>
+			<div>
+				<label for="setup-admin-password">Password</label>
+				<input id="setup-admin-password" type="password" name="admin-password"/>
+			</div>
+		</fieldset>
+
+		<fieldset>
+			<legend>Default Access</legend>
+			<p>
+				Now you'll need to decide which access level anonymous users have. This setting will{~s}
+				apply to anybody who's not logged in. It's normally best to leave this as read-only.{~s}
+				To completely disable unauthenticated access, uncheck everything.
+			</p>
+
+			<div>
+				<input id="setup-default-access-read" type="checkbox" name="default-access-read" {?formValues.default-access-read}checked{/formValues.default-access-read}/>
+				<label for="setup-default-access-read">Read (view all of the a11y data)</label>
+			</div>
+			<div>
+				<input id="setup-default-access-write" type="checkbox" name="default-access-write" {?formValues.default-access-write}checked{/formValues.default-access-write}/>
+				<label for="setup-default-access-write">Write (create and edit sites and URLs)</label>
+			</div>
+			<div>
+				<input id="setup-default-access-delete" type="checkbox" name="default-access-delete" {?formValues.default-access-delete}checked{/formValues.default-access-delete}/>
+				<label for="setup-default-access-delete">Delete (delete sites and URLs)</label>
+			</div>
+			<div>
+				<input id="setup-default-access-admin" type="checkbox" name="default-access-admin" {?formValues.default-access-admin}checked{/formValues.default-access-admin}/>
+				<label for="setup-default-access-admin">Admin (add and administer users)</label>
+			</div>
+		</fieldset>
+
+		<p>
+			All done? <input type="submit" value="Setup {appName}"/>
+		</p>
+
+	</form>
+
+{/content}

--- a/view/style/main.scss
+++ b/view/style/main.scss
@@ -1,2 +1,8 @@
 
 @import "example";
+
+// Temporary classes just to make things clear
+// in my "unstyled" test pages
+.form-error {
+	color: red;
+}


### PR DESCRIPTION
This configures the admin user and default permissions. I'm PRing into a `users` branch which will be a little long-running. I'd rather do this in small chunks to avoid a massive review at the end. I'd like to add tests for this, but they'll arrive in a later PR.

The process creates an admin users and sets default permissions. Currently you can't actually log in as that user and the permissions mean nothing, but hey it's a logical chunk of work 😄

## If you've never set up Sidekick:

  1. Follow the instructions in the README, the setup page should be the first thing you see when you open Sidekick in-browser

## If you've set up before:

  1. You'll need to migrate down and then up again to get the new database structure (sorry):
    `make db-migrate-down db-migrate-up`
  2. Run Sidekick and open in-browser, you should see the setup page

## Testing again:

Once you've tried the setup step, you can get back to it by deleting everything in the `settings` and `users` table, then restart the application.

```
psql -d pa11y_sidekick -c "delete from settings; delete from users;"
```

## Screenshot

<img width="360" alt="Setup page screenshot" src="https://cloud.githubusercontent.com/assets/138944/25523086/606ff744-2bfd-11e7-8722-0ae3e3d42458.png">

