### PR TITLE
Use the user and default permissions to control access

### DIFF
--- a/controller/api/v1.js
+++ b/controller/api/v1.js
@@ -2,6 +2,7 @@
 
 const bodyParser = require('body-parser');
 const httpError = require('http-errors');
+const requirePermission = require('../../middleware/require-permission');
 
 module.exports = dashboard => {
 	const app = dashboard.app;
@@ -14,7 +15,7 @@ module.exports = dashboard => {
 	});
 
 	// Create a site
-	app.post('/api/v1/sites', parseJsonBody, (request, response, next) => {
+	app.post('/api/v1/sites', requirePermission('write'), parseJsonBody, (request, response, next) => {
 		model.site.create(request.body)
 			.then(siteId => {
 				response.set('Location', `/api/v1/sites/${siteId}`);
@@ -30,7 +31,7 @@ module.exports = dashboard => {
 	});
 
 	// Get all sites
-	app.get('/api/v1/sites', (request, response, next) => {
+	app.get('/api/v1/sites', requirePermission('read'), (request, response, next) => {
 		model.site.getAll()
 			.then(sites => {
 				response.locals.sites = sites;
@@ -40,7 +41,7 @@ module.exports = dashboard => {
 	});
 
 	// Get a site by ID
-	app.get('/api/v1/sites/:siteId', (request, response, next) => {
+	app.get('/api/v1/sites/:siteId', requirePermission('read'), (request, response, next) => {
 		model.site.getById(request.params.siteId)
 			.then(site => {
 				if (!site) {
@@ -53,7 +54,7 @@ module.exports = dashboard => {
 	});
 
 	// Edit a site by ID
-	app.patch('/api/v1/sites/:siteId', parseJsonBody, (request, response, next) => {
+	app.patch('/api/v1/sites/:siteId', requirePermission('write'), parseJsonBody, (request, response, next) => {
 		model.site.getById(request.params.siteId)
 			.then(site => {
 				if (!site) {
@@ -74,7 +75,7 @@ module.exports = dashboard => {
 	});
 
 	// Delete a site by ID
-	app.delete('/api/v1/sites/:siteId', (request, response, next) => {
+	app.delete('/api/v1/sites/:siteId', requirePermission('delete'), (request, response, next) => {
 		model.site.getById(request.params.siteId)
 			.then(site => {
 				if (!site) {
@@ -90,7 +91,7 @@ module.exports = dashboard => {
 	});
 
 	// Create a URL
-	app.post('/api/v1/sites/:siteId/urls', parseJsonBody, (request, response, next) => {
+	app.post('/api/v1/sites/:siteId/urls', requirePermission('write'), parseJsonBody, (request, response, next) => {
 		model.site.getById(request.params.siteId)
 			.then(site => {
 				if (!site) {
@@ -113,7 +114,7 @@ module.exports = dashboard => {
 	});
 
 	// Get a site's URLs
-	app.get('/api/v1/sites/:siteId/urls', (request, response, next) => {
+	app.get('/api/v1/sites/:siteId/urls', requirePermission('read'), (request, response, next) => {
 		model.site.getById(request.params.siteId)
 			.then(site => {
 				if (!site) {
@@ -129,7 +130,7 @@ module.exports = dashboard => {
 	});
 
 	// Get a site's results
-	app.get('/api/v1/sites/:siteId/results', (request, response, next) => {
+	app.get('/api/v1/sites/:siteId/results', requirePermission('read'), (request, response, next) => {
 		model.site.getById(request.params.siteId)
 			.then(site => {
 				if (!site) {
@@ -145,7 +146,7 @@ module.exports = dashboard => {
 	});
 
 	// Get a URL by ID
-	app.get('/api/v1/sites/:siteId/urls/:urlId', (request, response, next) => {
+	app.get('/api/v1/sites/:siteId/urls/:urlId', requirePermission('read'), (request, response, next) => {
 		model.url.getByIdAndSite(request.params.urlId, request.params.siteId)
 			.then(url => {
 				if (!url) {
@@ -158,7 +159,7 @@ module.exports = dashboard => {
 	});
 
 	// Edit a URL by ID
-	app.patch('/api/v1/sites/:siteId/urls/:urlId', parseJsonBody, (request, response, next) => {
+	app.patch('/api/v1/sites/:siteId/urls/:urlId', requirePermission('write'), parseJsonBody, (request, response, next) => {
 		model.url.getByIdAndSite(request.params.urlId, request.params.siteId)
 			.then(url => {
 				if (!url) {
@@ -179,7 +180,7 @@ module.exports = dashboard => {
 	});
 
 	// Delete a URL by ID
-	app.delete('/api/v1/sites/:siteId/urls/:urlId', (request, response, next) => {
+	app.delete('/api/v1/sites/:siteId/urls/:urlId', requirePermission('delete'), (request, response, next) => {
 		model.url.getByIdAndSite(request.params.urlId, request.params.siteId)
 			.then(url => {
 				if (!url) {
@@ -195,7 +196,7 @@ module.exports = dashboard => {
 	});
 
 	// Get a URL's results
-	app.get('/api/v1/sites/:siteId/urls/:urlId/results', (request, response, next) => {
+	app.get('/api/v1/sites/:siteId/urls/:urlId/results', requirePermission('read'), (request, response, next) => {
 		model.url.getByIdAndSite(request.params.urlId, request.params.siteId)
 			.then(url => {
 				if (!url) {
@@ -211,7 +212,7 @@ module.exports = dashboard => {
 	});
 
 	// Get a result by ID
-	app.get('/api/v1/sites/:siteId/urls/:urlId/results/:resultId', (request, response, next) => {
+	app.get('/api/v1/sites/:siteId/urls/:urlId/results/:resultId', requirePermission('read'), (request, response, next) => {
 		model.result.getByIdAndUrlAndSite(request.params.resultId, request.params.urlId, request.params.siteId)
 			.then(result => {
 				if (!result) {
@@ -224,7 +225,7 @@ module.exports = dashboard => {
 	});
 
 	// Delete a result by ID
-	app.delete('/api/v1/sites/:siteId/urls/:urlId/results/:resultId', (request, response, next) => {
+	app.delete('/api/v1/sites/:siteId/urls/:urlId/results/:resultId', requirePermission('delete'), (request, response, next) => {
 		model.result.getByIdAndUrlAndSite(request.params.resultId, request.params.urlId, request.params.siteId)
 			.then(result => {
 				if (!result) {

--- a/controller/front-end/auth.js
+++ b/controller/front-end/auth.js
@@ -24,6 +24,7 @@ module.exports = dashboard => {
 		model.user.getByEmailAndPassword(request.body.email, request.body.password)
 			.then(user => {
 				request.session.userId = user.id;
+				response.set('Cache-Control', 'no-cache, no-store, must-revalidate');
 				response.redirect(request.body.referer || '/');
 			})
 			.catch(error => {
@@ -38,6 +39,7 @@ module.exports = dashboard => {
 	// Logout page
 	app.get('/logout', (request, response) => {
 		delete request.session;
+		response.set('Cache-Control', 'no-cache, no-store, must-revalidate');
 		response.redirect('/');
 	});
 

--- a/controller/front-end/index.js
+++ b/controller/front-end/index.js
@@ -13,13 +13,19 @@ module.exports = dashboard => {
 			return next();
 		}
 
-		// Render the home page
-		model.site.getAll()
-			.then(sites => {
-				response.locals.sites = sites;
-				response.render('index');
-			})
-			.catch(next);
+		// Render the home page if the user has permission
+		if (model.user.hasPermission(request.user, 'read')) {
+			return model.site.getAll()
+				.then(sites => {
+					response.locals.sites = sites;
+					response.render('index');
+				})
+				.catch(next);
+		}
+
+		// No read permissions, redirect to login
+		response.set('Cache-Control', 'no-cache, no-store, must-revalidate');
+		response.redirect('/login');
 	});
 
 };

--- a/controller/front-end/main.js
+++ b/controller/front-end/main.js
@@ -1,13 +1,14 @@
 'use strict';
 
 const httpError = require('http-errors');
+const requirePermission = require('../../middleware/require-permission');
 
 module.exports = dashboard => {
 	const app = dashboard.app;
 	const model = dashboard.model;
 
 	// Site page
-	app.get('/sites/:siteId', (request, response, next) => {
+	app.get('/sites/:siteId', requirePermission('read'), (request, response, next) => {
 		model.site.getById(request.params.siteId)
 			.then(site => {
 				if (!site) {

--- a/controller/front-end/setup.js
+++ b/controller/front-end/setup.js
@@ -63,6 +63,7 @@ module.exports = dashboard => {
 				return model.settings.edit(dashboard.settings);
 			})
 			.then(() => {
+				response.set('Cache-Control', 'no-cache, no-store, must-revalidate');
 				response.redirect('/');
 			})
 			.catch(error => {

--- a/data/seed/test/permissions/README.md
+++ b/data/seed/test/permissions/README.md
@@ -1,0 +1,4 @@
+
+# Permissions Test Seed Data
+
+This seed data includes a set up system with no authentication required and multiple users with varying permissions. It's used to test that the permissions system works correctly.

--- a/data/seed/test/permissions/settings.js
+++ b/data/seed/test/permissions/settings.js
@@ -1,0 +1,24 @@
+/* eslint max-len: 'off' */
+'use strict';
+
+// Note: IDs in here are referenced in the integration
+// tests, so should not be changed.
+exports.seed = (database, Promise) => {
+	return Promise.resolve().then(() => {
+		// Add settings to the site
+		return database('settings').insert({
+			id: 'ryr3Batkb',
+			data: JSON.stringify({
+				defaultPermissions: {
+					allowRead: false,
+					allowWrite: false,
+					allowDelete: false,
+					allowAdmin: false
+				},
+				setupComplete: true,
+				// See users seed data for this value
+				superAdminId: 'H1tA5TKkb'
+			})
+		});
+	});
+};

--- a/data/seed/test/permissions/sites.js
+++ b/data/seed/test/permissions/sites.js
@@ -1,0 +1,5 @@
+/* eslint max-len: 'off' */
+'use strict';
+
+// We just use the base seed data sites
+module.exports = require('../base/sites');

--- a/data/seed/test/permissions/users.js
+++ b/data/seed/test/permissions/users.js
@@ -1,0 +1,56 @@
+/* eslint max-len: 'off' */
+'use strict';
+
+// Note: IDs in here are referenced in the integration
+// tests, so should not be changed.
+exports.seed = (database, Promise) => {
+	return Promise.resolve().then(() => {
+		// Add a bunch of users to the site
+		return database('users').insert([
+			{
+				id: 'H1tA5TKkb',
+				email: 'admin@example.com',
+				// The password for this user is "password"
+				password: '$2a$15$EJPlCXi18TnWhgcarpvPYOcFzMOnwdS0sZyNTS8BRbaVpVuNOY15C',
+				apiKey: 'mock-admin-api-key',
+				allowRead: true,
+				allowWrite: true,
+				allowDelete: true,
+				allowAdmin: true
+			},
+			{
+				id: 'SkWuKxJeZ',
+				email: 'readonly@example.com',
+				// The password for this user is "password"
+				password: '$2a$15$EJPlCXi18TnWhgcarpvPYOcFzMOnwdS0sZyNTS8BRbaVpVuNOY15C',
+				apiKey: 'mock-readonly-api-key',
+				allowRead: true,
+				allowWrite: false,
+				allowDelete: false,
+				allowAdmin: false
+			},
+			{
+				id: 'ByrOKx1lb',
+				email: 'readwrite@example.com',
+				// The password for this user is "password"
+				password: '$2a$15$EJPlCXi18TnWhgcarpvPYOcFzMOnwdS0sZyNTS8BRbaVpVuNOY15C',
+				apiKey: 'mock-readwrite-api-key',
+				allowRead: true,
+				allowWrite: true,
+				allowDelete: false,
+				allowAdmin: false
+			},
+			{
+				id: 'HkaOYeyxZ',
+				email: 'readwritedelete@example.com',
+				// The password for this user is "password"
+				password: '$2a$15$EJPlCXi18TnWhgcarpvPYOcFzMOnwdS0sZyNTS8BRbaVpVuNOY15C',
+				apiKey: 'mock-readwritedelete-api-key',
+				allowRead: true,
+				allowWrite: true,
+				allowDelete: true,
+				allowAdmin: false
+			}
+		]);
+	});
+};

--- a/lib/sidekick.js
+++ b/lib/sidekick.js
@@ -188,6 +188,7 @@ function loadModels(dashboard) {
 // middleware early on in the start up
 function createExpressApplication(dashboard) {
 	const app = express();
+	app.dashboard = dashboard;
 
 	app.set('env', dashboard.environment);
 	app.set('json spaces', 4);

--- a/middleware/require-permission.js
+++ b/middleware/require-permission.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const httpError = require('http-errors');
+
+module.exports = requirePermission;
+
+// This middleware is used to require a certain
+// permission before executing middleware further
+// down the chain. E.g. requiring write permission
+// before processing a form
+function requirePermission(permission) {
+	return (request, response, next) => {
+		const dashboard = request.app.dashboard;
+		if (dashboard.model.user.hasPermission(request.user, permission)) {
+			return next();
+		}
+		next(httpError(403, 'You do not have permission to do this'));
+	};
+}

--- a/model/user.js
+++ b/model/user.js
@@ -67,6 +67,22 @@ module.exports = dashboard => {
 			return bcrypt.compare(password, hash);
 		},
 
+		// Check whether a user has a permission
+		hasPermission(user, permission) {
+			switch (permission) {
+				case 'read':
+					return user.allowRead || false;
+				case 'write':
+					return user.allowWrite || false;
+				case 'delete':
+					return user.allowDelete || false;
+				case 'admin':
+					return user.allowAdmin || false;
+				default:
+					return false;
+			}
+		},
+
 		// Validate/sanitize user data input
 		cleanInput(data) {
 			try {

--- a/test/integration/api/v1/delete-sites-id-urls-id-results-id.js
+++ b/test/integration/api/v1/delete-sites-id-urls-id-results-id.js
@@ -99,4 +99,34 @@ describe('DELETE /api/v1/sites/:siteId/urls/:urlId/results/:resultId', () => {
 
 	});
 
+	describe('when the default permissions do not allow delete access and a delete API key is specified', () => {
+
+		beforeEach(() => {
+			request = agent
+				.delete(`/api/v1/sites/${siteId}/urls/${urlId}/results/${resultId}`)
+				.set('X-Api-Key', 'mock-readwritedelete-api-key');
+			return loadSeedData(dashboard, 'permissions');
+		});
+
+		it('responds with a 200 status', done => {
+			request.expect(200).end(done);
+		});
+
+	});
+
+	describe('when the default permissions do not allow delete access and no API key is specified', () => {
+
+		beforeEach(() => {
+			request = agent
+				.delete(`/api/v1/sites/${siteId}/urls/${urlId}/results/${resultId}`)
+				.set('X-Api-Key', 'mock-readwrite-api-key');
+			return loadSeedData(dashboard, 'permissions');
+		});
+
+		it('responds with a 403 status', done => {
+			request.expect(403).end(done);
+		});
+
+	});
+
 });

--- a/test/integration/api/v1/delete-sites-id-urls-id.js
+++ b/test/integration/api/v1/delete-sites-id-urls-id.js
@@ -89,4 +89,34 @@ describe('DELETE /api/v1/sites/:siteId/urls/:urlId', () => {
 
 	});
 
+	describe('when the default permissions do not allow delete access and a delete API key is specified', () => {
+
+		beforeEach(() => {
+			request = agent
+				.delete(`/api/v1/sites/${siteId}/urls/${urlId}`)
+				.set('X-Api-Key', 'mock-readwritedelete-api-key');
+			return loadSeedData(dashboard, 'permissions');
+		});
+
+		it('responds with a 200 status', done => {
+			request.expect(200).end(done);
+		});
+
+	});
+
+	describe('when the default permissions do not allow delete access and no API key is specified', () => {
+
+		beforeEach(() => {
+			request = agent
+				.delete(`/api/v1/sites/${siteId}/urls/${urlId}`)
+				.set('X-Api-Key', 'mock-readwrite-api-key');
+			return loadSeedData(dashboard, 'permissions');
+		});
+
+		it('responds with a 403 status', done => {
+			request.expect(403).end(done);
+		});
+
+	});
+
 });

--- a/test/integration/api/v1/delete-sites-id.js
+++ b/test/integration/api/v1/delete-sites-id.js
@@ -64,4 +64,34 @@ describe('DELETE /api/v1/sites/:siteId', () => {
 
 	});
 
+	describe('when the default permissions do not allow delete access and a delete API key is specified', () => {
+
+		beforeEach(() => {
+			request = agent
+				.delete(`/api/v1/sites/${siteId}`)
+				.set('X-Api-Key', 'mock-readwritedelete-api-key');
+			return loadSeedData(dashboard, 'permissions');
+		});
+
+		it('responds with a 200 status', done => {
+			request.expect(200).end(done);
+		});
+
+	});
+
+	describe('when the default permissions do not allow delete access and no API key is specified', () => {
+
+		beforeEach(() => {
+			request = agent
+				.delete(`/api/v1/sites/${siteId}`)
+				.set('X-Api-Key', 'mock-readwrite-api-key');
+			return loadSeedData(dashboard, 'permissions');
+		});
+
+		it('responds with a 403 status', done => {
+			request.expect(403).end(done);
+		});
+
+	});
+
 });

--- a/test/integration/api/v1/get-sites-id-results.js
+++ b/test/integration/api/v1/get-sites-id-results.js
@@ -8,35 +8,44 @@ describe('GET /api/v1/sites/:siteId/results', () => {
 	let request;
 	let siteId;
 
+
 	beforeEach(() => {
 		siteId = 'testsite-1';
-		request = agent.get(`/api/v1/sites/${siteId}/results`);
-		return loadSeedData(dashboard, 'base');
 	});
 
-	it('responds with a 200 status', done => {
-		request.expect(200).end(done);
-	});
+	describe('when everything is valid', () => {
 
-	it('responds with JSON', done => {
-		request.expect('Content-Type', 'application/json; charset=utf-8').end(done);
-	});
+		beforeEach(() => {
+			siteId = 'testsite-1';
+			request = agent.get(`/api/v1/sites/${siteId}/results`);
+			return loadSeedData(dashboard, 'base');
+		});
 
-	it('responds with all of the results in the database for the given site as an array', done => {
-		dashboard.database.select('*').from('results').orderBy('createdAt', 'desc').where({
-			site: siteId
-		})
-		.then(results => {
-			const jsonifiedResults = JSON.parse(JSON.stringify(results))
-				.map(dashboard.model.result.prepareForOutput);
-			request.expect(response => {
-				assert.isObject(response.body);
-				assert.isArray(response.body.results);
-				assert.greaterThan(response.body.results.length, 0);
-				assert.deepEqual(response.body.results, jsonifiedResults);
-			}).end(done);
-		})
-		.catch(done);
+		it('responds with a 200 status', done => {
+			request.expect(200).end(done);
+		});
+
+		it('responds with JSON', done => {
+			request.expect('Content-Type', 'application/json; charset=utf-8').end(done);
+		});
+
+		it('responds with all of the results in the database for the given site as an array', done => {
+			dashboard.database.select('*').from('results').orderBy('createdAt', 'desc').where({
+				site: siteId
+			})
+			.then(results => {
+				const jsonifiedResults = JSON.parse(JSON.stringify(results))
+					.map(dashboard.model.result.prepareForOutput);
+				request.expect(response => {
+					assert.isObject(response.body);
+					assert.isArray(response.body.results);
+					assert.greaterThan(response.body.results.length, 0);
+					assert.deepEqual(response.body.results, jsonifiedResults);
+				}).end(done);
+			})
+			.catch(done);
+		});
+
 	});
 
 	describe('when the site has no results', () => {
@@ -73,6 +82,32 @@ describe('GET /api/v1/sites/:siteId/results', () => {
 
 		it('responds with a 404 status', done => {
 			request.expect(404).end(done);
+		});
+
+	});
+
+	describe('when the default permissions do not allow read access and a read API key is specified', () => {
+
+		beforeEach(() => {
+			request = agent.get(`/api/v1/sites/${siteId}/results`).set('X-Api-Key', 'mock-readonly-api-key');
+			return loadSeedData(dashboard, 'permissions');
+		});
+
+		it('responds with a 200 status', done => {
+			request.expect(200).end(done);
+		});
+
+	});
+
+	describe('when the default permissions do not allow read access and no API key is specified', () => {
+
+		beforeEach(() => {
+			request = agent.get(`/api/v1/sites/${siteId}/results`);
+			return loadSeedData(dashboard, 'permissions');
+		});
+
+		it('responds with a 403 status', done => {
+			request.expect(403).end(done);
 		});
 
 	});

--- a/test/integration/api/v1/get-sites-id-urls-id-results-id.js
+++ b/test/integration/api/v1/get-sites-id-urls-id-results-id.js
@@ -14,30 +14,37 @@ describe('GET /api/v1/sites/:siteId/urls/:urlId/results/:resultId', () => {
 		siteId = 'testsite-1';
 		urlId = 'testurl-1';
 		resultId = 'testresult-1';
-		request = agent.get(`/api/v1/sites/${siteId}/urls/${urlId}/results/${resultId}`);
-		return loadSeedData(dashboard, 'base');
 	});
 
-	it('responds with a 200 status', done => {
-		request.expect(200).end(done);
-	});
+	describe('when everything is valid', () => {
 
-	it('responds with JSON', done => {
-		request.expect('Content-Type', 'application/json; charset=utf-8').end(done);
-	});
+		beforeEach(() => {
+			request = agent.get(`/api/v1/sites/${siteId}/urls/${urlId}/results/${resultId}`);
+			return loadSeedData(dashboard, 'base');
+		});
 
-	it('responds with the result as an object', done => {
-		dashboard.database.select('*').from('results').where({id: resultId})
-			.then(results => {
-				const jsonifiedResult = dashboard.model.result
-					.prepareForOutput(JSON.parse(JSON.stringify(results[0])));
-				request.expect(response => {
-					assert.isObject(response.body);
-					assert.isObject(response.body.result);
-					assert.deepEqual(response.body.result, jsonifiedResult);
-				}).end(done);
-			})
-			.catch(done);
+		it('responds with a 200 status', done => {
+			request.expect(200).end(done);
+		});
+
+		it('responds with JSON', done => {
+			request.expect('Content-Type', 'application/json; charset=utf-8').end(done);
+		});
+
+		it('responds with the result as an object', done => {
+			dashboard.database.select('*').from('results').where({id: resultId})
+				.then(results => {
+					const jsonifiedResult = dashboard.model.result
+						.prepareForOutput(JSON.parse(JSON.stringify(results[0])));
+					request.expect(response => {
+						assert.isObject(response.body);
+						assert.isObject(response.body.result);
+						assert.deepEqual(response.body.result, jsonifiedResult);
+					}).end(done);
+				})
+				.catch(done);
+		});
+
 	});
 
 	describe('when a site with the given ID does not exist', () => {
@@ -88,6 +95,32 @@ describe('GET /api/v1/sites/:siteId/urls/:urlId/results/:resultId', () => {
 
 		it('responds with a 404 status', done => {
 			request.expect(404).end(done);
+		});
+
+	});
+
+	describe('when the default permissions do not allow read access and a read API key is specified', () => {
+
+		beforeEach(() => {
+			request = agent.get(`/api/v1/sites/${siteId}/urls/${urlId}/results/${resultId}`).set('X-Api-Key', 'mock-readonly-api-key');
+			return loadSeedData(dashboard, 'permissions');
+		});
+
+		it('responds with a 200 status', done => {
+			request.expect(200).end(done);
+		});
+
+	});
+
+	describe('when the default permissions do not allow read access and no API key is specified', () => {
+
+		beforeEach(() => {
+			request = agent.get(`/api/v1/sites/${siteId}/urls/${urlId}/results/${resultId}`);
+			return loadSeedData(dashboard, 'permissions');
+		});
+
+		it('responds with a 403 status', done => {
+			request.expect(403).end(done);
 		});
 
 	});

--- a/test/integration/api/v1/get-sites-id-urls-id-results.js
+++ b/test/integration/api/v1/get-sites-id-urls-id-results.js
@@ -12,34 +12,41 @@ describe('GET /api/v1/sites/:siteId/urls/:urlId/results', () => {
 	beforeEach(() => {
 		siteId = 'testsite-1';
 		urlId = 'testurl-1';
-		request = agent.get(`/api/v1/sites/${siteId}/urls/${urlId}/results`);
-		return loadSeedData(dashboard, 'base');
 	});
 
-	it('responds with a 200 status', done => {
-		request.expect(200).end(done);
-	});
+	describe('when everything is valid', () => {
 
-	it('responds with JSON', done => {
-		request.expect('Content-Type', 'application/json; charset=utf-8').end(done);
-	});
+		beforeEach(() => {
+			request = agent.get(`/api/v1/sites/${siteId}/urls/${urlId}/results`);
+			return loadSeedData(dashboard, 'base');
+		});
 
-	it('responds with all of the results in the database for the given site/url as an array', done => {
-		dashboard.database.select('*').from('results').orderBy('createdAt', 'desc').where({
-			url: urlId,
-			site: siteId
-		})
-		.then(results => {
-			const jsonifiedResults = JSON.parse(JSON.stringify(results))
-				.map(dashboard.model.result.prepareForOutput);
-			request.expect(response => {
-				assert.isObject(response.body);
-				assert.isArray(response.body.results);
-				assert.greaterThan(response.body.results.length, 0);
-				assert.deepEqual(response.body.results, jsonifiedResults);
-			}).end(done);
-		})
-		.catch(done);
+		it('responds with a 200 status', done => {
+			request.expect(200).end(done);
+		});
+
+		it('responds with JSON', done => {
+			request.expect('Content-Type', 'application/json; charset=utf-8').end(done);
+		});
+
+		it('responds with all of the results in the database for the given site/url as an array', done => {
+			dashboard.database.select('*').from('results').orderBy('createdAt', 'desc').where({
+				url: urlId,
+				site: siteId
+			})
+			.then(results => {
+				const jsonifiedResults = JSON.parse(JSON.stringify(results))
+					.map(dashboard.model.result.prepareForOutput);
+				request.expect(response => {
+					assert.isObject(response.body);
+					assert.isArray(response.body.results);
+					assert.greaterThan(response.body.results.length, 0);
+					assert.deepEqual(response.body.results, jsonifiedResults);
+				}).end(done);
+			})
+			.catch(done);
+		});
+
 	});
 
 	describe('when the URL has no results', () => {
@@ -102,6 +109,32 @@ describe('GET /api/v1/sites/:siteId/urls/:urlId/results', () => {
 
 		it('responds with a 404 status', done => {
 			request.expect(404).end(done);
+		});
+
+	});
+
+	describe('when the default permissions do not allow read access and a read API key is specified', () => {
+
+		beforeEach(() => {
+			request = agent.get(`/api/v1/sites/${siteId}/urls/${urlId}/results`).set('X-Api-Key', 'mock-readonly-api-key');
+			return loadSeedData(dashboard, 'permissions');
+		});
+
+		it('responds with a 200 status', done => {
+			request.expect(200).end(done);
+		});
+
+	});
+
+	describe('when the default permissions do not allow read access and no API key is specified', () => {
+
+		beforeEach(() => {
+			request = agent.get(`/api/v1/sites/${siteId}/urls/${urlId}/results`);
+			return loadSeedData(dashboard, 'permissions');
+		});
+
+		it('responds with a 403 status', done => {
+			request.expect(403).end(done);
 		});
 
 	});

--- a/test/integration/api/v1/get-sites-id-urls.js
+++ b/test/integration/api/v1/get-sites-id-urls.js
@@ -10,31 +10,38 @@ describe('GET /api/v1/sites/:siteId/urls', () => {
 
 	beforeEach(() => {
 		siteId = 'testsite-1';
-		request = agent.get(`/api/v1/sites/${siteId}/urls`);
-		return loadSeedData(dashboard, 'base');
 	});
 
-	it('responds with a 200 status', done => {
-		request.expect(200).end(done);
-	});
+	describe('when everything is valid', () => {
 
-	it('responds with JSON', done => {
-		request.expect('Content-Type', 'application/json; charset=utf-8').end(done);
-	});
+		beforeEach(() => {
+			request = agent.get(`/api/v1/sites/${siteId}/urls`);
+			return loadSeedData(dashboard, 'base');
+		});
 
-	it('responds with all of the urls in the database for the given site as an array', done => {
-		dashboard.database.select('*').from('urls').where({site: siteId}).orderBy('name')
-			.then(urls => {
-				const jsonifiedUrls = JSON.parse(JSON.stringify(urls))
-					.map(dashboard.model.url.prepareForOutput);
-				request.expect(response => {
-					assert.isObject(response.body);
-					assert.isArray(response.body.urls);
-					assert.greaterThan(response.body.urls.length, 0);
-					assert.deepEqual(response.body.urls, jsonifiedUrls);
-				}).end(done);
-			})
-			.catch(done);
+		it('responds with a 200 status', done => {
+			request.expect(200).end(done);
+		});
+
+		it('responds with JSON', done => {
+			request.expect('Content-Type', 'application/json; charset=utf-8').end(done);
+		});
+
+		it('responds with all of the urls in the database for the given site as an array', done => {
+			dashboard.database.select('*').from('urls').where({site: siteId}).orderBy('name')
+				.then(urls => {
+					const jsonifiedUrls = JSON.parse(JSON.stringify(urls))
+						.map(dashboard.model.url.prepareForOutput);
+					request.expect(response => {
+						assert.isObject(response.body);
+						assert.isArray(response.body.urls);
+						assert.greaterThan(response.body.urls.length, 0);
+						assert.deepEqual(response.body.urls, jsonifiedUrls);
+					}).end(done);
+				})
+				.catch(done);
+		});
+
 	});
 
 	describe('when the site has no URLs', () => {
@@ -73,6 +80,32 @@ describe('GET /api/v1/sites/:siteId/urls', () => {
 
 		it('responds with a 404 status', done => {
 			request.expect(404).end(done);
+		});
+
+	});
+
+	describe('when the default permissions do not allow read access and a read API key is specified', () => {
+
+		beforeEach(() => {
+			request = agent.get(`/api/v1/sites/${siteId}/urls`).set('X-Api-Key', 'mock-readonly-api-key');
+			return loadSeedData(dashboard, 'permissions');
+		});
+
+		it('responds with a 200 status', done => {
+			request.expect(200).end(done);
+		});
+
+	});
+
+	describe('when the default permissions do not allow read access and no API key is specified', () => {
+
+		beforeEach(() => {
+			request = agent.get(`/api/v1/sites/${siteId}/urls`);
+			return loadSeedData(dashboard, 'permissions');
+		});
+
+		it('responds with a 403 status', done => {
+			request.expect(403).end(done);
 		});
 
 	});

--- a/test/integration/api/v1/get-sites-id.js
+++ b/test/integration/api/v1/get-sites-id.js
@@ -10,35 +10,42 @@ describe('GET /api/v1/sites/:siteId', () => {
 
 	beforeEach(() => {
 		siteId = 'testsite-1';
-		request = agent.get(`/api/v1/sites/${siteId}`);
-		return loadSeedData(dashboard, 'base');
 	});
 
-	it('responds with a 200 status', done => {
-		request.expect(200).end(done);
-	});
+	describe('when everything is valid', () => {
 
-	it('responds with JSON', done => {
-		request.expect('Content-Type', 'application/json; charset=utf-8').end(done);
-	});
+		beforeEach(() => {
+			request = agent.get(`/api/v1/sites/${siteId}`);
+			return loadSeedData(dashboard, 'base');
+		});
 
-	it('responds with the site as an object', done => {
-		dashboard.database.select('sites.*')
-			.leftJoin('urls', 'sites.id', 'urls.site')
-			.count('urls.id as urlCount')
-			.groupBy('sites.id')
-			.from('sites')
-			.where({'sites.id': siteId})
-			.then(sites => {
-				const jsonifiedSite = dashboard.model.site
-					.prepareForOutput(JSON.parse(JSON.stringify(sites[0])));
-				request.expect(response => {
-					assert.isObject(response.body);
-					assert.isObject(response.body.site);
-					assert.deepEqual(response.body.site, jsonifiedSite);
-				}).end(done);
-			})
-			.catch(done);
+		it('responds with a 200 status', done => {
+			request.expect(200).end(done);
+		});
+
+		it('responds with JSON', done => {
+			request.expect('Content-Type', 'application/json; charset=utf-8').end(done);
+		});
+
+		it('responds with the site as an object', done => {
+			dashboard.database.select('sites.*')
+				.leftJoin('urls', 'sites.id', 'urls.site')
+				.count('urls.id as urlCount')
+				.groupBy('sites.id')
+				.from('sites')
+				.where({'sites.id': siteId})
+				.then(sites => {
+					const jsonifiedSite = dashboard.model.site
+						.prepareForOutput(JSON.parse(JSON.stringify(sites[0])));
+					request.expect(response => {
+						assert.isObject(response.body);
+						assert.isObject(response.body.site);
+						assert.deepEqual(response.body.site, jsonifiedSite);
+					}).end(done);
+				})
+				.catch(done);
+		});
+
 	});
 
 	describe('when a site with the given ID does not exist', () => {
@@ -50,6 +57,32 @@ describe('GET /api/v1/sites/:siteId', () => {
 
 		it('responds with a 404 status', done => {
 			request.expect(404).end(done);
+		});
+
+	});
+
+	describe('when the default permissions do not allow read access and a read API key is specified', () => {
+
+		beforeEach(() => {
+			request = agent.get(`/api/v1/sites/${siteId}`).set('X-Api-Key', 'mock-readonly-api-key');
+			return loadSeedData(dashboard, 'permissions');
+		});
+
+		it('responds with a 200 status', done => {
+			request.expect(200).end(done);
+		});
+
+	});
+
+	describe('when the default permissions do not allow read access and no API key is specified', () => {
+
+		beforeEach(() => {
+			request = agent.get(`/api/v1/sites/${siteId}`);
+			return loadSeedData(dashboard, 'permissions');
+		});
+
+		it('responds with a 403 status', done => {
+			request.expect(403).end(done);
 		});
 
 	});

--- a/test/integration/api/v1/get-sites.js
+++ b/test/integration/api/v1/get-sites.js
@@ -7,37 +7,67 @@ const loadSeedData = require('../../helper/load-seed-data');
 describe('GET /api/v1/sites', () => {
 	let request;
 
-	beforeEach(() => {
-		request = agent.get('/api/v1/sites');
-		return loadSeedData(dashboard, 'base');
+	describe('when everything is valid', () => {
+
+		beforeEach(() => {
+			request = agent.get('/api/v1/sites');
+			return loadSeedData(dashboard, 'base');
+		});
+
+		it('responds with a 200 status', done => {
+			request.expect(200).end(done);
+		});
+
+		it('responds with JSON', done => {
+			request.expect('Content-Type', 'application/json; charset=utf-8').end(done);
+		});
+
+		it('responds with all of the sites in the database as an array', done => {
+			dashboard.database.select('sites.*')
+				.leftJoin('urls', 'sites.id', 'urls.site')
+				.count('urls.id as urlCount')
+				.groupBy('sites.id')
+				.from('sites')
+				.orderBy('sites.name')
+				.then(sites => {
+					const jsonifiedSites = JSON.parse(JSON.stringify(sites))
+						.map(dashboard.model.site.prepareForOutput);
+					request.expect(response => {
+						assert.isObject(response.body);
+						assert.isArray(response.body.sites);
+						assert.greaterThan(response.body.sites.length, 0);
+						assert.deepEqual(response.body.sites, jsonifiedSites);
+					}).end(done);
+				})
+				.catch(done);
+		});
+
 	});
 
-	it('responds with a 200 status', done => {
-		request.expect(200).end(done);
+	describe('when the default permissions do not allow read access and a read API key is specified', () => {
+
+		beforeEach(() => {
+			request = agent.get('/api/v1/sites').set('X-Api-Key', 'mock-readonly-api-key');
+			return loadSeedData(dashboard, 'permissions');
+		});
+
+		it('responds with a 200 status', done => {
+			request.expect(200).end(done);
+		});
+
 	});
 
-	it('responds with JSON', done => {
-		request.expect('Content-Type', 'application/json; charset=utf-8').end(done);
-	});
+	describe('when the default permissions do not allow read access and no API key is specified', () => {
 
-	it('responds with all of the sites in the database as an array', done => {
-		dashboard.database.select('sites.*')
-			.leftJoin('urls', 'sites.id', 'urls.site')
-			.count('urls.id as urlCount')
-			.groupBy('sites.id')
-			.from('sites')
-			.orderBy('sites.name')
-			.then(sites => {
-				const jsonifiedSites = JSON.parse(JSON.stringify(sites))
-					.map(dashboard.model.site.prepareForOutput);
-				request.expect(response => {
-					assert.isObject(response.body);
-					assert.isArray(response.body.sites);
-					assert.greaterThan(response.body.sites.length, 0);
-					assert.deepEqual(response.body.sites, jsonifiedSites);
-				}).end(done);
-			})
-			.catch(done);
+		beforeEach(() => {
+			request = agent.get('/api/v1/sites');
+			return loadSeedData(dashboard, 'permissions');
+		});
+
+		it('responds with a 403 status', done => {
+			request.expect(403).end(done);
+		});
+
 	});
 
 });

--- a/test/integration/api/v1/get.js
+++ b/test/integration/api/v1/get.js
@@ -6,17 +6,21 @@ const loadSeedData = require('../../helper/load-seed-data');
 describe('GET /api/v1', () => {
 	let request;
 
-	beforeEach(() => {
-		request = agent.get('/api/v1');
-		return loadSeedData(dashboard, 'base');
-	});
+	describe('when everything is valid', () => {
 
-	it('responds with a 200 status', done => {
-		request.expect(200).end(done);
-	});
+		beforeEach(() => {
+			request = agent.get('/api/v1');
+			return loadSeedData(dashboard, 'base');
+		});
 
-	it('responds with HTML', done => {
-		request.expect('Content-Type', 'text/html; charset=utf-8').end(done);
+		it('responds with a 200 status', done => {
+			request.expect(200).end(done);
+		});
+
+		it('responds with HTML', done => {
+			request.expect('Content-Type', 'text/html; charset=utf-8').end(done);
+		});
+
 	});
 
 	describe('with no User-Agent header', () => {

--- a/test/integration/api/v1/patch-sites-id-urls-id.js
+++ b/test/integration/api/v1/patch-sites-id-urls-id.js
@@ -320,4 +320,38 @@ describe('PATCH /api/v1/sites/:siteId/urls/:urlId', () => {
 
 	});
 
+	describe('when the default permissions do not allow write access and a write API key is specified', () => {
+
+		beforeEach(() => {
+			request = agent
+				.patch(`/api/v1/sites/${siteId}/urls/${urlId}`)
+				.set('Content-Type', 'application/json')
+				.set('X-Api-Key', 'mock-readwrite-api-key')
+				.send(testEdits);
+			return loadSeedData(dashboard, 'permissions');
+		});
+
+		it('responds with a 200 status', done => {
+			request.expect(200).end(done);
+		});
+
+	});
+
+	describe('when the default permissions do not allow write access and no API key is specified', () => {
+
+		beforeEach(() => {
+			request = agent
+				.patch(`/api/v1/sites/${siteId}/urls/${urlId}`)
+				.set('Content-Type', 'application/json')
+				.set('X-Api-Key', 'mock-readonly-api-key')
+				.send(testEdits);
+			return loadSeedData(dashboard, 'permissions');
+		});
+
+		it('responds with a 403 status', done => {
+			request.expect(403).end(done);
+		});
+
+	});
+
 });

--- a/test/integration/api/v1/patch-sites-id.js
+++ b/test/integration/api/v1/patch-sites-id.js
@@ -206,4 +206,38 @@ describe('PATCH /api/v1/sites/:siteId', () => {
 
 	});
 
+	describe('when the default permissions do not allow write access and a write API key is specified', () => {
+
+		beforeEach(() => {
+			request = agent
+				.patch(`/api/v1/sites/${siteId}`)
+				.set('Content-Type', 'application/json')
+				.set('X-Api-Key', 'mock-readwrite-api-key')
+				.send(testEdits);
+			return loadSeedData(dashboard, 'permissions');
+		});
+
+		it('responds with a 200 status', done => {
+			request.expect(200).end(done);
+		});
+
+	});
+
+	describe('when the default permissions do not allow write access and no API key is specified', () => {
+
+		beforeEach(() => {
+			request = agent
+				.patch(`/api/v1/sites/${siteId}`)
+				.set('Content-Type', 'application/json')
+				.set('X-Api-Key', 'mock-readonly-api-key')
+				.send(testEdits);
+			return loadSeedData(dashboard, 'permissions');
+		});
+
+		it('responds with a 403 status', done => {
+			request.expect(403).end(done);
+		});
+
+	});
+
 });

--- a/test/integration/api/v1/post-sites-id-urls.js
+++ b/test/integration/api/v1/post-sites-id-urls.js
@@ -267,4 +267,38 @@ describe('POST /api/v1/sites/:siteId/urls', () => {
 
 	});
 
+	describe('when the default permissions do not allow write access and a write API key is specified', () => {
+
+		beforeEach(() => {
+			request = agent
+				.post(`/api/v1/sites/${siteId}/urls`)
+				.set('Content-Type', 'application/json')
+				.set('X-Api-Key', 'mock-readwrite-api-key')
+				.send(testUrl);
+			return loadSeedData(dashboard, 'permissions');
+		});
+
+		it('responds with a 201 status', done => {
+			request.expect(201).end(done);
+		});
+
+	});
+
+	describe('when the default permissions do not allow write access and no API key is specified', () => {
+
+		beforeEach(() => {
+			request = agent
+				.post(`/api/v1/sites/${siteId}/urls`)
+				.set('Content-Type', 'application/json')
+				.set('X-Api-Key', 'mock-readonly-api-key')
+				.send(testUrl);
+			return loadSeedData(dashboard, 'permissions');
+		});
+
+		it('responds with a 403 status', done => {
+			request.expect(403).end(done);
+		});
+
+	});
+
 });

--- a/test/integration/api/v1/post-sites.js
+++ b/test/integration/api/v1/post-sites.js
@@ -196,4 +196,38 @@ describe('POST /api/v1/sites', () => {
 
 	});
 
+	describe('when the default permissions do not allow write access and a write API key is specified', () => {
+
+		beforeEach(() => {
+			request = agent
+				.post('/api/v1/sites')
+				.set('Content-Type', 'application/json')
+				.set('X-Api-Key', 'mock-readwrite-api-key')
+				.send(testSite);
+			return loadSeedData(dashboard, 'permissions');
+		});
+
+		it('responds with a 201 status', done => {
+			request.expect(201).end(done);
+		});
+
+	});
+
+	describe('when the default permissions do not allow write access and no API key is specified', () => {
+
+		beforeEach(() => {
+			request = agent
+				.post('/api/v1/sites')
+				.set('Content-Type', 'application/json')
+				.set('X-Api-Key', 'mock-readonly-api-key')
+				.send(testSite);
+			return loadSeedData(dashboard, 'permissions');
+		});
+
+		it('responds with a 403 status', done => {
+			request.expect(403).end(done);
+		});
+
+	});
+
 });

--- a/test/integration/front-end/get-logout.js
+++ b/test/integration/front-end/get-logout.js
@@ -2,24 +2,20 @@
 'use strict';
 
 const assert = require('proclaim');
+const authenticateWithUser = require('../helper/authenticate-with-user');
 const loadSeedData = require('../helper/load-seed-data');
 
 describe('GET /logout', () => {
 	let request;
 
 	beforeEach(() => {
-		request = agent
-			.get('/logout')
-			.set('Cookie', 'sidekick.sid=mock-sid');
-		return loadSeedData(dashboard, 'base')
-			.then(() => {
-				return dashboard.database('sessions').insert({
-					sid: 'mock-sid',
-					sess: JSON.stringify({
-						userId: 'H1tA5TKkb'
-					}),
-					expired: new Date(Date.now() + 86400000)
-				});
+		return Promise.resolve()
+			.then(() => loadSeedData(dashboard, 'base'))
+			.then(() => authenticateWithUser('admin@example.com', 'password'))
+			.then(cookie => {
+				request = agent
+					.get('/logout')
+					.set('Cookie', cookie);
 			});
 	});
 

--- a/test/integration/front-end/get.js
+++ b/test/integration/front-end/get.js
@@ -1,22 +1,67 @@
 /* global agent, dashboard */
 'use strict';
 
+const authenticateWithUser = require('../helper/authenticate-with-user');
 const loadSeedData = require('../helper/load-seed-data');
 
 describe('GET /', () => {
 	let request;
 
-	beforeEach(() => {
-		request = agent.get('/');
-		return loadSeedData(dashboard, 'base');
+	describe('unauthenticated', () => {
+
+		beforeEach(() => {
+			request = agent.get('/');
+			return loadSeedData(dashboard, 'base');
+		});
+
+		it('responds with a 200 status', done => {
+			request.expect(200).end(done);
+		});
+
+		it('responds with HTML', done => {
+			request.expect('Content-Type', 'text/html; charset=utf-8').end(done);
+		});
+
 	});
 
-	it('responds with a 200 status', done => {
-		request.expect(200).end(done);
+	describe('unauthenticated when the default permissions do not allow read access', () => {
+
+		beforeEach(() => {
+			request = agent.get('/');
+			return loadSeedData(dashboard, 'permissions');
+		});
+
+		it('responds with a 302 status', done => {
+			request.expect(302).end(done);
+		});
+
+		it('responds with a location header pointing to the login page', done => {
+			request.expect('Location', '/login').end(done);
+		});
+
 	});
 
-	it('responds with HTML', done => {
-		request.expect('Content-Type', 'text/html; charset=utf-8').end(done);
+	describe('authenticated with a user who has read access', () => {
+
+		beforeEach(() => {
+			return Promise.resolve()
+				.then(() => loadSeedData(dashboard, 'permissions'))
+				.then(() => authenticateWithUser('readonly@example.com', 'password'))
+				.then(cookie => {
+					request = agent
+						.get('/')
+						.set('Cookie', cookie);
+				});
+		});
+
+		it('responds with a 200 status', done => {
+			request.expect(200).end(done);
+		});
+
+		it('responds with HTML', done => {
+			request.expect('Content-Type', 'text/html; charset=utf-8').end(done);
+		});
+
 	});
 
 });

--- a/test/integration/helper/authenticate-with-user.js
+++ b/test/integration/helper/authenticate-with-user.js
@@ -1,0 +1,28 @@
+/* global agent */
+'use strict';
+
+module.exports = authenticateWithUser;
+
+// This helper function adds a session for the given
+// user and returns the session cookie
+function authenticateWithUser(email, password) {
+	return new Promise((resolve, reject) => {
+		let cookie;
+		agent
+			.post('/login')
+			.set('Content-Type', 'application/x-www-form-urlencoded')
+			.send({
+				email,
+				password
+			})
+			.expect(response => {
+				cookie = response.headers['set-cookie'][0].split(';')[0];
+			})
+			.end(error => {
+				if (error) {
+					return reject(error);
+				}
+				resolve(cookie);
+			});
+	});
+}

--- a/test/unit/middleware/require-permission.js
+++ b/test/unit/middleware/require-permission.js
@@ -1,0 +1,80 @@
+/* eslint max-len: 'off' */
+'use strict';
+
+const assert = require('proclaim');
+const sinon = require('sinon');
+
+describe('middleware/require-permission', () => {
+	let express;
+	let requirePermission;
+	let sidekick;
+
+	beforeEach(() => {
+		express = require('../mock/express.mock');
+		sidekick = require('../mock/sidekick.mock');
+		requirePermission = require('../../../middleware/require-permission');
+	});
+
+	it('exports a function', () => {
+		assert.isFunction(requirePermission);
+	});
+
+	describe('requirePermission(permission)', () => {
+		let middleware;
+
+		beforeEach(() => {
+			middleware = requirePermission('read');
+		});
+
+		it('returns a middleware function', () => {
+			assert.isFunction(middleware);
+		});
+
+		describe('middleware(request, response, next)', () => {
+			let next;
+
+			beforeEach(() => {
+				express.mockRequest.user = {
+					id: 'mock-id',
+					email: 'mock-email'
+				};
+				express.mockApp.dashboard = sidekick.mockDashboard;
+				sidekick.mockDashboard.model.user = {
+					hasPermission: sinon.stub().returns(true)
+				};
+				next = sinon.spy();
+				return middleware(express.mockRequest, express.mockResponse, next);
+			});
+
+			it('checks whether the current user has the specified permission', () => {
+				assert.calledOnce(sidekick.mockDashboard.model.user.hasPermission);
+				assert.calledWithExactly(sidekick.mockDashboard.model.user.hasPermission, express.mockRequest.user, 'read');
+			});
+
+			it('calls `next` with no error', () => {
+				assert.calledOnce(next);
+				assert.calledWithExactly(next);
+			});
+
+			describe('when the user does not have the specified permission', () => {
+
+				beforeEach(() => {
+					next.reset();
+					sidekick.mockDashboard.model.user.hasPermission.returns(false);
+					return middleware(express.mockRequest, express.mockResponse, next);
+				});
+
+				it('calls `next` with a 403 error', () => {
+					assert.calledOnce(next);
+					assert.instanceOf(next.firstCall.args[0], Error);
+					assert.strictEqual(next.firstCall.args[0].status, 403);
+					assert.strictEqual(next.firstCall.args[0].message, 'You do not have permission to do this');
+				});
+
+			});
+
+		});
+
+	});
+
+});

--- a/test/unit/mock/express.mock.js
+++ b/test/unit/mock/express.mock.js
@@ -28,6 +28,7 @@ const mockApp = module.exports.mockApp = {
 const mockStaticMiddleware = module.exports.mockStaticMiddleware = sinon.stub();
 
 module.exports.mockRequest = {
+	app: mockApp,
 	headers: {},
 	session: {}
 };


### PR DESCRIPTION
This adds permission verification to all existing routes, so now the settings you add in the setup step actually do something. The API endpoints now require an API key, which currently users can't get at – the next step is to add a profile page where you can copy your API key, as well as documentation for authenticating with the API.

[**This PR is easier to review with whitespace removed**](https://github.com/pa11y/sidekick/pull/72/files?w=1)