### PR TITLE
Add a user profile page

### DIFF
--- a/controller/api/index.js
+++ b/controller/api/index.js
@@ -3,9 +3,9 @@
 module.exports = dashboard => {
 	const app = dashboard.app;
 
-	// API page (redirect to latest version)
+	// API page (redirect to latest version documentation)
 	app.get('/api', (request, response) => {
-		response.redirect('/api/v1');
+		response.redirect('/docs/api/v1');
 	});
 
 };

--- a/controller/api/v1.js
+++ b/controller/api/v1.js
@@ -11,7 +11,7 @@ module.exports = dashboard => {
 
 	// API documentation
 	app.get('/api/v1', (request, response) => {
-		response.render('api-v1');
+		response.redirect('/docs/api/v1');
 	});
 
 	// Create a site

--- a/controller/front-end/auth.js
+++ b/controller/front-end/auth.js
@@ -24,7 +24,6 @@ module.exports = dashboard => {
 		model.user.getByEmailAndPassword(request.body.email, request.body.password)
 			.then(user => {
 				request.session.userId = user.id;
-				response.set('Cache-Control', 'no-cache, no-store, must-revalidate');
 				response.redirect(request.body.referer || '/');
 			})
 			.catch(error => {
@@ -39,7 +38,6 @@ module.exports = dashboard => {
 	// Logout page
 	app.get('/logout', (request, response) => {
 		delete request.session;
-		response.set('Cache-Control', 'no-cache, no-store, must-revalidate');
 		response.redirect('/');
 	});
 

--- a/controller/front-end/docs.js
+++ b/controller/front-end/docs.js
@@ -1,0 +1,13 @@
+'use strict';
+
+const requirePermission = require('../../middleware/require-permission');
+
+module.exports = dashboard => {
+	const app = dashboard.app;
+
+	// V1 API documentation
+	app.get('/docs/api/v1', requirePermission('read'), (request, response) => {
+		response.render('api-v1');
+	});
+
+};

--- a/controller/front-end/index.js
+++ b/controller/front-end/index.js
@@ -24,7 +24,6 @@ module.exports = dashboard => {
 		}
 
 		// No read permissions, redirect to login
-		response.set('Cache-Control', 'no-cache, no-store, must-revalidate');
 		response.redirect('/login');
 	});
 

--- a/controller/front-end/profile.js
+++ b/controller/front-end/profile.js
@@ -21,7 +21,7 @@ module.exports = dashboard => {
 	// Regenerate the current user's API key
 	app.post('/profile/regenerate-api-key', (request, response, next) => {
 		if (!request.user.isLoggedIn) {
-			return httpError(401);
+			return next(httpError(401));
 		}
 		model.user.regenerateApiKey(request.user.id)
 			.then(() => {

--- a/controller/front-end/profile.js
+++ b/controller/front-end/profile.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const httpError = require('http-errors');
+
+module.exports = dashboard => {
+	const app = dashboard.app;
+	const model = dashboard.model;
+
+	// Current user profile page
+	app.get('/profile', (request, response) => {
+
+		// If no user is present, redirect to login
+		if (!request.user.isLoggedIn) {
+			return response.redirect('/login?referer=/profile');
+		}
+
+		// Render the profile page
+		response.render('profile');
+	});
+
+	// Regenerate the current user's API key
+	app.post('/profile/regenerate-api-key', (request, response, next) => {
+		if (!request.user.isLoggedIn) {
+			return httpError(401);
+		}
+		model.user.regenerateApiKey(request.user.id)
+			.then(() => {
+				response.redirect('/profile');
+			})
+			.catch(next);
+	});
+
+};

--- a/controller/front-end/setup.js
+++ b/controller/front-end/setup.js
@@ -63,7 +63,6 @@ module.exports = dashboard => {
 				return model.settings.edit(dashboard.settings);
 			})
 			.then(() => {
-				response.set('Cache-Control', 'no-cache, no-store, must-revalidate');
 				response.redirect('/');
 			})
 			.catch(error => {

--- a/data/seed/test/base/users.js
+++ b/data/seed/test/base/users.js
@@ -12,7 +12,7 @@ exports.seed = (database, Promise) => {
 				email: 'admin@example.com',
 				// The password for this user is "password"
 				password: '$2a$15$EJPlCXi18TnWhgcarpvPYOcFzMOnwdS0sZyNTS8BRbaVpVuNOY15C',
-				apiKey: 'c1e35c4d-8165-4133-a557-d323515e6f45',
+				apiKey: 'mock-admin-api-key',
 				allowRead: true,
 				allowWrite: true,
 				allowDelete: true,

--- a/lib/sidekick.js
+++ b/lib/sidekick.js
@@ -17,6 +17,7 @@ const addResponseViewData = require('../middleware/add-response-view-data');
 const compression = require('compression');
 const cors = require('../middleware/cors');
 const defaults = require('lodash/defaultsDeep');
+const disableCache = require('../middleware/disable-cache');
 const express = require('express');
 const fs = require('fs');
 const handleErrors = require('../middleware/handle-errors');
@@ -204,6 +205,10 @@ function createExpressApplication(dashboard) {
 
 	// Set up CORS middleware to allow cross-domain requests
 	app.use(cors());
+
+	// Disable browser caching (for alpha/beta, we'll do this properly later)
+	app.disable('etag');
+	app.use(disableCache());
 
 	// Compress responses with deflate
 	app.use(compression());

--- a/middleware/disable-cache.js
+++ b/middleware/disable-cache.js
@@ -1,0 +1,15 @@
+'use strict';
+
+module.exports = disableCache;
+
+// This middleware disables the browser cache.
+function disableCache() {
+	return (request, response, next) => {
+		response.set({
+			'Cache-Control': 'no-cache, no-store, must-revalidate',
+			Pragma: 'no-cache',
+			Expires: '0'
+		});
+		next();
+	};
+}

--- a/middleware/load-user-api-key.js
+++ b/middleware/load-user-api-key.js
@@ -21,7 +21,9 @@ function loadUserFromApiKey(dashboard) {
 						allowAdmin: (defaultPermissions ? defaultPermissions.allowAdmin : false)
 					};
 				}
-				return model.user.getByApiKey(request.headers['x-api-key'], true);
+				return model.user.getByApiKey(request.headers['x-api-key'], {
+					safe: true
+				});
 			})
 			.then(user => {
 				if (!user) {

--- a/middleware/load-user-api-key.js
+++ b/middleware/load-user-api-key.js
@@ -21,7 +21,7 @@ function loadUserFromApiKey(dashboard) {
 						allowAdmin: (defaultPermissions ? defaultPermissions.allowAdmin : false)
 					};
 				}
-				return model.user.getByApiKey(request.headers['x-api-key']);
+				return model.user.getByApiKey(request.headers['x-api-key'], true);
 			})
 			.then(user => {
 				if (!user) {

--- a/middleware/load-user-session.js
+++ b/middleware/load-user-session.js
@@ -12,7 +12,9 @@ function loadUserFromSession(dashboard) {
 				if (!request.session.userId) {
 					return null;
 				}
-				return model.user.getById(request.session.userId, true);
+				return model.user.getById(request.session.userId, {
+					safe: true
+				});
 			})
 			.then(user => {
 				if (user) {

--- a/middleware/load-user-session.js
+++ b/middleware/load-user-session.js
@@ -12,7 +12,7 @@ function loadUserFromSession(dashboard) {
 				if (!request.session.userId) {
 					return null;
 				}
-				return model.user.getById(request.session.userId);
+				return model.user.getById(request.session.userId, true);
 			})
 			.then(user => {
 				if (user) {

--- a/model/user.js
+++ b/model/user.js
@@ -19,23 +19,23 @@ module.exports = dashboard => {
 		},
 
 		// Get a single user by ID
-		getById(id, safe) {
+		getById(id, options) {
 			return this._rawGetById(id).then(user => {
-				return (user ? this.prepareForOutput(user, safe) : user);
+				return (user ? this.prepareForOutput(user, options) : user);
 			});
 		},
 
 		// Get a single user by email and password
-		getByEmailAndPassword(email, password, safe) {
+		getByEmailAndPassword(email, password, options) {
 			return this._rawGetByEmailAndPassword(email, password).then(user => {
-				return (user ? this.prepareForOutput(user, safe) : user);
+				return (user ? this.prepareForOutput(user, options) : user);
 			});
 		},
 
 		// Get a single user by API key
-		getByApiKey(apiKey, safe) {
+		getByApiKey(apiKey, options) {
 			return this._rawGetByApiKey(apiKey).then(user => {
-				return (user ? this.prepareForOutput(user, safe) : user);
+				return (user ? this.prepareForOutput(user, options) : user);
 			});
 		},
 
@@ -147,9 +147,10 @@ module.exports = dashboard => {
 		},
 
 		// Prepare a user object for output
-		prepareForOutput(user, safe) {
+		prepareForOutput(user, options) {
+			options = options || {};
 			delete user.password;
-			if (!safe) {
+			if (!options.safe) {
 				delete user.apiKey;
 			}
 			user.paths = {

--- a/model/user.js
+++ b/model/user.js
@@ -19,23 +19,23 @@ module.exports = dashboard => {
 		},
 
 		// Get a single user by ID
-		getById(id) {
+		getById(id, safe) {
 			return this._rawGetById(id).then(user => {
-				return (user ? this.prepareForOutput(user) : user);
+				return (user ? this.prepareForOutput(user, safe) : user);
 			});
 		},
 
 		// Get a single user by email and password
-		getByEmailAndPassword(email, password) {
+		getByEmailAndPassword(email, password, safe) {
 			return this._rawGetByEmailAndPassword(email, password).then(user => {
-				return (user ? this.prepareForOutput(user) : user);
+				return (user ? this.prepareForOutput(user, safe) : user);
 			});
 		},
 
 		// Get a single user by API key
-		getByApiKey(apiKey) {
+		getByApiKey(apiKey, safe) {
 			return this._rawGetByApiKey(apiKey).then(user => {
-				return (user ? this.prepareForOutput(user) : user);
+				return (user ? this.prepareForOutput(user, safe) : user);
 			});
 		},
 
@@ -53,6 +53,18 @@ module.exports = dashboard => {
 					cleanData.apiKey = uuid();
 					cleanData.createdAt = cleanData.updatedAt = new Date();
 					return this._rawCreate(cleanData);
+				});
+		},
+
+		// Regenerate a user's API key by ID
+		regenerateApiKey(id) {
+			return database(table)
+				.where({id})
+				.update({
+					apiKey: uuid()
+				}, 'id')
+				.then(ids => {
+					return Boolean(ids.length);
 				});
 		},
 
@@ -135,9 +147,11 @@ module.exports = dashboard => {
 		},
 
 		// Prepare a user object for output
-		prepareForOutput(user) {
+		prepareForOutput(user, safe) {
 			delete user.password;
-			delete user.apiKey;
+			if (!safe) {
+				delete user.apiKey;
+			}
 			user.paths = {
 				api: `/api/v1/users/${user.id}`
 			};

--- a/test/integration/api/get.js
+++ b/test/integration/api/get.js
@@ -15,8 +15,8 @@ describe('GET /api', () => {
 		request.expect(302).end(done);
 	});
 
-	it('responds with a Location header pointing to /api/v1', done => {
-		request.expect('Location', '/api/v1').end(done);
+	it('responds with a Location header pointing to /docs/api/v1', done => {
+		request.expect('Location', '/docs/api/v1').end(done);
 	});
 
 });

--- a/test/integration/api/v1/get.js
+++ b/test/integration/api/v1/get.js
@@ -6,47 +6,17 @@ const loadSeedData = require('../../helper/load-seed-data');
 describe('GET /api/v1', () => {
 	let request;
 
-	describe('when everything is valid', () => {
-
-		beforeEach(() => {
-			request = agent.get('/api/v1');
-			return loadSeedData(dashboard, 'base');
-		});
-
-		it('responds with a 200 status', done => {
-			request.expect(200).end(done);
-		});
-
-		it('responds with HTML', done => {
-			request.expect('Content-Type', 'text/html; charset=utf-8').end(done);
-		});
-
+	beforeEach(() => {
+		request = agent.get('/api/v1');
+		return loadSeedData(dashboard, 'base');
 	});
 
-	describe('with no User-Agent header', () => {
-		let request;
+	it('responds with a 302 status', done => {
+		request.expect(302).end(done);
+	});
 
-		beforeEach(() => {
-			request = agent.get('/api/v1').set('User-Agent', '');
-		});
-
-		it('responds with a 400 status', done => {
-			request.expect(400).end(done);
-		});
-
-		it('responds with HTML', done => {
-			request.expect('Content-Type', 'application/json; charset=utf-8').end(done);
-		});
-
-		it('responds with an error message', done => {
-			request.expect({
-				error: {
-					message: 'User-Agent header is required',
-					status: 400
-				}
-			}).end(done);
-		});
-
+	it('responds with a Location header pointing to /docs/api/v1', done => {
+		request.expect('Location', '/docs/api/v1').end(done);
 	});
 
 });

--- a/test/integration/front-end/get-docs-api-v1.js
+++ b/test/integration/front-end/get-docs-api-v1.js
@@ -1,0 +1,22 @@
+/* global agent, dashboard */
+'use strict';
+
+const loadSeedData = require('../helper/load-seed-data');
+
+describe('GET /docs/api/v1', () => {
+	let request;
+
+	beforeEach(() => {
+		request = agent.get('/docs/api/v1');
+		return loadSeedData(dashboard, 'base');
+	});
+
+	it('responds with a 200 status', done => {
+		request.expect(200).end(done);
+	});
+
+	it('responds with HTML', done => {
+		request.expect('Content-Type', 'text/html; charset=utf-8').end(done);
+	});
+
+});

--- a/test/integration/front-end/get-profile.js
+++ b/test/integration/front-end/get-profile.js
@@ -1,0 +1,67 @@
+/* global agent, dashboard */
+'use strict';
+
+const authenticateWithUser = require('../helper/authenticate-with-user');
+const jsdom = require('jsdom').jsdom;
+const loadSeedData = require('../helper/load-seed-data');
+
+describe.only('GET /profile', () => {
+	let request;
+
+	describe('authenticated', () => {
+
+		beforeEach(() => {
+			return Promise.resolve()
+				.then(() => loadSeedData(dashboard, 'base'))
+				.then(() => authenticateWithUser('admin@example.com', 'password'))
+				.then(cookie => {
+					request = agent
+						.get('/profile')
+						.set('Cookie', cookie);
+				});
+		});
+
+		it('responds with a 200 status', done => {
+			request.expect(200).end(done);
+		});
+
+		it('responds with HTML', done => {
+			request.expect('Content-Type', 'text/html; charset=utf-8').end(done);
+		});
+
+		it('responds with the profile page', done => {
+			request.expect(response => {
+				jsdom.env(response.text, (error, window) => {
+					const document = window.document;
+
+					// Check page title
+					assert.match(document.querySelector('title').textContent, /profile/i);
+
+					// Check that API key and regenerate button are present
+					const form = document.querySelector('form[action="/profile/regenerate-api-key"]');
+					assert.strictEqual(form.getAttribute('method'), 'post');
+					assert.match(form.textContent, /mock-admin-api-key/i);
+				});
+			}).end(done);
+		});
+
+	});
+
+	describe('unauthenticated', () => {
+
+		beforeEach(() => {
+			request = agent.get('/profile');
+			return loadSeedData(dashboard, 'base');
+		});
+
+		it('responds with a 302 status', done => {
+			request.expect(302).end(done);
+		});
+
+		it('responds with a location header pointing to the login page', done => {
+			request.expect('Location', '/login?referer=/profile').end(done);
+		});
+
+	});
+
+});

--- a/test/integration/front-end/get-profile.js
+++ b/test/integration/front-end/get-profile.js
@@ -1,6 +1,7 @@
 /* global agent, dashboard */
 'use strict';
 
+const assert = require('proclaim');
 const authenticateWithUser = require('../helper/authenticate-with-user');
 const jsdom = require('jsdom').jsdom;
 const loadSeedData = require('../helper/load-seed-data');

--- a/test/integration/front-end/get-profile.js
+++ b/test/integration/front-end/get-profile.js
@@ -5,7 +5,7 @@ const authenticateWithUser = require('../helper/authenticate-with-user');
 const jsdom = require('jsdom').jsdom;
 const loadSeedData = require('../helper/load-seed-data');
 
-describe.only('GET /profile', () => {
+describe('GET /profile', () => {
 	let request;
 
 	describe('authenticated', () => {

--- a/test/integration/front-end/post-profile-regenerate-api-key.js
+++ b/test/integration/front-end/post-profile-regenerate-api-key.js
@@ -1,0 +1,61 @@
+/* global agent, dashboard */
+'use strict';
+
+const assert = require('proclaim');
+const authenticateWithUser = require('../helper/authenticate-with-user');
+const jsdom = require('jsdom').jsdom;
+const loadSeedData = require('../helper/load-seed-data');
+
+describe('GET /profile/regenerate-api-key', () => {
+	let request;
+
+	describe('authenticated', () => {
+
+		beforeEach(() => {
+			return Promise.resolve()
+				.then(() => loadSeedData(dashboard, 'base'))
+				.then(() => authenticateWithUser('admin@example.com', 'password'))
+				.then(cookie => {
+					request = agent
+						.post('/profile/regenerate-api-key')
+						.set('Cookie', cookie);
+				});
+		});
+
+		it('responds with a 302 status', done => {
+			request.expect(302).end(done);
+		});
+
+		it('responds with a location header pointing to profile page', done => {
+			request.expect('Location', '/profile').end(done);
+		});
+
+		it.only('updates the user API key in the database', done => {
+			request.end(() => {
+				dashboard.database.select('*').from('users').where({email: 'admin@example.com'})
+					.then(users => {
+						assert.isDefined(users[0]);
+						assert.notStrictEqual(users[0].apiKey, 'mock-admin-api-key');
+						assert.match(users[0].apiKey, /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i);
+						done();
+					})
+					.catch(done);
+			});
+		});
+
+	});
+
+	describe('unauthenticated', () => {
+
+		beforeEach(() => {
+			request = agent.post('/profile/regenerate-api-key');
+			return loadSeedData(dashboard, 'base');
+		});
+
+		it('responds with a 401 status', done => {
+			request.expect(401).end(done);
+		});
+
+	});
+
+});

--- a/test/integration/front-end/post-profile-regenerate-api-key.js
+++ b/test/integration/front-end/post-profile-regenerate-api-key.js
@@ -3,7 +3,6 @@
 
 const assert = require('proclaim');
 const authenticateWithUser = require('../helper/authenticate-with-user');
-const jsdom = require('jsdom').jsdom;
 const loadSeedData = require('../helper/load-seed-data');
 
 describe('GET /profile/regenerate-api-key', () => {

--- a/test/integration/front-end/post-profile-regenerate-api-key.js
+++ b/test/integration/front-end/post-profile-regenerate-api-key.js
@@ -30,7 +30,7 @@ describe('GET /profile/regenerate-api-key', () => {
 			request.expect('Location', '/profile').end(done);
 		});
 
-		it.only('updates the user API key in the database', done => {
+		it('updates the user API key in the database', done => {
 			request.end(() => {
 				dashboard.database.select('*').from('users').where({email: 'admin@example.com'})
 					.then(users => {

--- a/test/unit/lib/sidekick.js
+++ b/test/unit/lib/sidekick.js
@@ -15,6 +15,7 @@ describe('lib/sidekick', () => {
 	let cors;
 	let defaults;
 	let defaultViewData;
+	let disableCache;
 	let expectedMigrationConfig;
 	let expectedSeedConfig;
 	let express;
@@ -56,6 +57,9 @@ describe('lib/sidekick', () => {
 
 		defaults = sinon.spy(require('lodash/defaultsDeep'));
 		mockery.registerMock('lodash/defaultsDeep', defaults);
+
+		disableCache = require('../mock/disable-cache.mock');
+		mockery.registerMock('../middleware/disable-cache', disableCache);
 
 		express = require('../mock/express.mock');
 		mockery.registerMock('express', express);
@@ -320,6 +324,15 @@ describe('lib/sidekick', () => {
 				assert.calledWithExactly(express.mockApp.use, cors.mockMiddleware);
 			});
 
+			it('disables etag generation', () => {
+				assert.calledWithExactly(express.mockApp.disable, 'etag');
+			});
+
+			it('creates and mounts a disable-cache middleware', () => {
+				assert.calledOnce(disableCache);
+				assert.calledWithExactly(express.mockApp.use, disableCache.mockMiddleware);
+			});
+
 			it('creates and mounts a compression middleware', () => {
 				assert.calledOnce(compression);
 				assert.calledWithExactly(compression);
@@ -482,6 +495,7 @@ describe('lib/sidekick', () => {
 				assert.callOrder(
 					express.mockApp.use.withArgs(morgan.mockMiddleware).named('morgan'),
 					express.mockApp.use.withArgs(cors.mockMiddleware).named('cors'),
+					express.mockApp.use.withArgs(disableCache.mockMiddleware).named('disableCache'),
 					express.mockApp.use.withArgs(compression.mockMiddleware).named('compression'),
 					express.mockApp.use.withArgs(express.mockStaticMiddleware).named('static'),
 					express.mockApp.use.withArgs(resaveBrowserify.mockResaver).named('browserify'),

--- a/test/unit/middleware/disable-cache.js
+++ b/test/unit/middleware/disable-cache.js
@@ -1,0 +1,57 @@
+/* eslint max-len: 'off' */
+'use strict';
+
+const assert = require('proclaim');
+const sinon = require('sinon');
+
+describe('middleware/disable-cache', () => {
+	let disableCache;
+	let express;
+
+	beforeEach(() => {
+		express = require('../mock/express.mock');
+		disableCache = require('../../../middleware/disable-cache');
+	});
+
+	it('exports a function', () => {
+		assert.isFunction(disableCache);
+	});
+
+	describe('disableCache()', () => {
+		let middleware;
+
+		beforeEach(() => {
+			middleware = disableCache();
+		});
+
+		it('returns a middleware function', () => {
+			assert.isFunction(middleware);
+		});
+
+		describe('middleware(request, response, next)', () => {
+			let next;
+
+			beforeEach(() => {
+				next = sinon.spy();
+				middleware(express.mockRequest, express.mockResponse, next);
+			});
+
+			it('sets cache control headers on the response', () => {
+				assert.calledOnce(express.mockResponse.set);
+				assert.calledWith(express.mockResponse.set, {
+					'Cache-Control': 'no-cache, no-store, must-revalidate',
+					Pragma: 'no-cache',
+					Expires: '0'
+				});
+			});
+
+			it('calls `next` with no error', () => {
+				assert.calledOnce(next);
+				assert.calledWithExactly(next);
+			});
+
+		});
+
+	});
+
+});

--- a/test/unit/middleware/load-user-api-key.js
+++ b/test/unit/middleware/load-user-api-key.js
@@ -51,7 +51,7 @@ describe('middleware/load-user-api-key', () => {
 
 			it('loads the user with the given API key from the database', () => {
 				assert.calledOnce(sidekick.mockDashboard.model.user.getByApiKey);
-				assert.calledWithExactly(sidekick.mockDashboard.model.user.getByApiKey, express.mockRequest.headers['x-api-key']);
+				assert.calledWithExactly(sidekick.mockDashboard.model.user.getByApiKey, express.mockRequest.headers['x-api-key'], true);
 			});
 
 			it('adds an `isLoggedIn` property to the user set to `true`', () => {

--- a/test/unit/middleware/load-user-api-key.js
+++ b/test/unit/middleware/load-user-api-key.js
@@ -51,7 +51,9 @@ describe('middleware/load-user-api-key', () => {
 
 			it('loads the user with the given API key from the database', () => {
 				assert.calledOnce(sidekick.mockDashboard.model.user.getByApiKey);
-				assert.calledWithExactly(sidekick.mockDashboard.model.user.getByApiKey, express.mockRequest.headers['x-api-key'], true);
+				assert.calledWith(sidekick.mockDashboard.model.user.getByApiKey, express.mockRequest.headers['x-api-key'], {
+					safe: true
+				});
 			});
 
 			it('adds an `isLoggedIn` property to the user set to `true`', () => {

--- a/test/unit/middleware/load-user-session.js
+++ b/test/unit/middleware/load-user-session.js
@@ -51,7 +51,9 @@ describe('middleware/load-user-session', () => {
 
 			it('loads the user with the given session ID from the database', () => {
 				assert.calledOnce(sidekick.mockDashboard.model.user.getById);
-				assert.calledWithExactly(sidekick.mockDashboard.model.user.getById, express.mockRequest.session.userId, true);
+				assert.calledWith(sidekick.mockDashboard.model.user.getById, express.mockRequest.session.userId, {
+					safe: true
+				});
 			});
 
 			it('adds an `isLoggedIn` property to the user set to `true`', () => {

--- a/test/unit/middleware/load-user-session.js
+++ b/test/unit/middleware/load-user-session.js
@@ -51,7 +51,7 @@ describe('middleware/load-user-session', () => {
 
 			it('loads the user with the given session ID from the database', () => {
 				assert.calledOnce(sidekick.mockDashboard.model.user.getById);
-				assert.calledWithExactly(sidekick.mockDashboard.model.user.getById, express.mockRequest.session.userId);
+				assert.calledWithExactly(sidekick.mockDashboard.model.user.getById, express.mockRequest.session.userId, true);
 			});
 
 			it('adds an `isLoggedIn` property to the user set to `true`', () => {

--- a/test/unit/mock/disable-cache.mock.js
+++ b/test/unit/mock/disable-cache.mock.js
@@ -1,0 +1,8 @@
+'use strict';
+
+const sinon = require('sinon');
+
+const disableCache = module.exports = sinon.stub();
+const mockMiddleware = disableCache.mockMiddleware = sinon.stub();
+
+disableCache.returns(mockMiddleware);

--- a/view/api-v1.dust
+++ b/view/api-v1.dust
@@ -7,13 +7,27 @@
 {<content}
 
 <h1>{appName} API</h1>
+
 <p>
 	This is the documentation for the {appName} API version 1.
 </p>
 <ul>
+	<li><a href="#authentication">Authentication</a></li>
 	<li><a href="#endpoints">Endpoints</a></li>
 	<li><a href="#entities">Entities</a></li>
 </ul>
+
+
+<h2 id="endpoints">Authentication</h2>
+
+<p>
+	Some endpoints require that you use an API key to authenticate, otherwise they will respond with a <code>403</code> error.{~s}
+	To authenticate, send your user's API key in an <code>X-Api-Key</code> header.
+</p>
+
+<p>
+	You can find your API key on <a href="/profile">your profile page</a>.
+</p>
 
 
 <h2 id="endpoints">Endpoints</h2>
@@ -22,11 +36,14 @@
 <h3><code>POST /api/v1/sites</code></h3>
 
 <p>
-	Create a new <a href="#entities-site">site</a> by POSTing JSON.
+	Create a new <a href="#entities-site">site</a> by POSTing JSON.{~s}
 	This responds with a <code>Location</code> header that points to the new site in the API.
 </p>
 
 <p>
+	{?settings.defaultPermissions.allowWrite}{:else}
+		This endpoint requires <a href="#authentication">authentication</a>.{~s}
+	{/settings.defaultPermissions.allowWrite}
 	Expects the following JSON POST body:
 </p>
 
@@ -40,6 +57,10 @@
 <p>
 	Get a list of all <a href="#entities-site">sites</a> as a JSON array.
 </p>
+
+{?settings.defaultPermissions.allowRead}{:else}
+	<p>This endpoint requires <a href="#authentication">authentication</a>.</p>
+{/settings.defaultPermissions.allowRead}
 
 <pre>{`{
 	sites: [
@@ -59,6 +80,10 @@
 	Get a single <a href="#entities-site">site</a> as a JSON object.
 </p>
 
+{?settings.defaultPermissions.allowRead}{:else}
+	<p>This endpoint requires <a href="#authentication">authentication</a>.</p>
+{/settings.defaultPermissions.allowRead}
+
 <pre>{`{
 	site: {
 		// site entity
@@ -69,11 +94,14 @@
 <h3><code>PATCH /api/v1/sites/<var>:siteId</var></code></h3>
 
 <p>
-	Edit a <a href="#entities-site">site</a> by POSTing JSON.
+	Edit a <a href="#entities-site">site</a> by POSTing JSON.{~s}
 	This responds with a <code>Location</code> header that points to the edited site in the API.
 </p>
 
 <p>
+	{?settings.defaultPermissions.allowWrite}{:else}
+		This endpoint requires <a href="#authentication">authentication</a>.{~s}
+	{/settings.defaultPermissions.allowWrite}
 	Expects the following JSON POST body:
 </p>
 
@@ -85,10 +113,14 @@
 <h3><code>DELETE /api/v1/sites/<var>:siteId</var></code></h3>
 
 <p>
-	Delete a <a href="#entities-site">site</a> by ID.
-	This also deletes all associated <a href="#entities-url">URL</a> and <a href="#entities-result">result</a> objects,
-	returning JSON which outlines how many records were deleted:
+	Delete a <a href="#entities-site">site</a> by ID.{~s}
+	This also deletes all associated <a href="#entities-url">URL</a> and <a href="#entities-result">result</a> objects,{~s}
+	returning JSON which outlines how many records were deleted.
 </p>
+
+{?settings.defaultPermissions.allowDelete}{:else}
+	<p>This endpoint requires <a href="#authentication">authentication</a>.</p>
+{/settings.defaultPermissions.allowDelete}
 
 <pre>{`{
 	deleted: {
@@ -105,6 +137,10 @@
 	Get a list of all site <a href="#entities-result">results</a> as a JSON array.
 </p>
 
+{?settings.defaultPermissions.allowRead}{:else}
+	<p>This endpoint requires <a href="#authentication">authentication</a>.</p>
+{/settings.defaultPermissions.allowRead}
+
 <pre>{`{
 	results: [
 		{
@@ -120,11 +156,14 @@
 <h3><code>POST /api/v1/sites/<var>:siteId</var>/urls</code></h3>
 
 <p>
-	Create a new <a href="#entities-url">URL</a> by POSTing JSON.
+	Create a new <a href="#entities-url">URL</a> by POSTing JSON.{~s}
 	This responds with a <code>Location</code> header that points to the new URL in the API.
 </p>
 
 <p>
+	{?settings.defaultPermissions.allowWrite}{:else}
+		This endpoint requires <a href="#authentication">authentication</a>.{~s}
+	{/settings.defaultPermissions.allowWrite}
 	Expects the following JSON POST body:
 </p>
 
@@ -139,6 +178,10 @@
 <p>
 	Get a list of all site <a href="#entities-url">URLs</a> as a JSON array.
 </p>
+
+{?settings.defaultPermissions.allowRead}{:else}
+	<p>This endpoint requires <a href="#authentication">authentication</a>.</p>
+{/settings.defaultPermissions.allowRead}
 
 <pre>{`{
 	urls: [
@@ -158,6 +201,10 @@
 	Get a single <a href="#entities-url">URL</a> as a JSON object.
 </p>
 
+{?settings.defaultPermissions.allowRead}{:else}
+	<p>This endpoint requires <a href="#authentication">authentication</a>.</p>
+{/settings.defaultPermissions.allowRead}
+
 <pre>{`{
 	url: {
 		// url entity
@@ -168,11 +215,14 @@
 <h3><code>PATCH /api/v1/sites/<var>:siteId</var>/urls/<var>:urlId</var></code></h3>
 
 <p>
-	Edit a <a href="#entities-url">URL</a> by POSTing JSON.
+	Edit a <a href="#entities-url">URL</a> by POSTing JSON.{~s}
 	This responds with a <code>Location</code> header that points to the edited URL in the API.
 </p>
 
 <p>
+	{?settings.defaultPermissions.allowWrite}{:else}
+		This endpoint requires <a href="#authentication">authentication</a>.{~s}
+	{/settings.defaultPermissions.allowWrite}
 	Expects the following JSON POST body:
 </p>
 
@@ -182,11 +232,35 @@
 }`}</pre>
 
 
+<h3><code>DELETE /api/v1/sites/<var>:siteId</var>/urls/<var>:urlId</var></code></h3>
+
+<p>
+	Delete a <a href="#entities-url">URL</a> by ID.{~s}
+	This also deletes all associated <a href="#entities-result">result</a> objects,{~s}
+	returning JSON which outlines how many records were deleted.
+</p>
+
+{?settings.defaultPermissions.allowDelete}{:else}
+	<p>This endpoint requires <a href="#authentication">authentication</a>.</p>
+{/settings.defaultPermissions.allowDelete}
+
+<pre>{`{
+	deleted: {
+		urls: 1,
+		results: 40
+	}
+}`}</pre>
+
+
 <h3><code>GET /api/v1/sites/<var>:siteId</var>/urls/<var>:urlId</var>/results</code></h3>
 
 <p>
 	Get a list of all URL <a href="#entities-result">results</a> as a JSON array.
 </p>
+
+{?settings.defaultPermissions.allowRead}{:else}
+	<p>This endpoint requires <a href="#authentication">authentication</a>.</p>
+{/settings.defaultPermissions.allowRead}
 
 <pre>{`{
 	results: [
@@ -206,9 +280,30 @@
 	Get a single <a href="#entities-result">result</a> as a JSON object.
 </p>
 
+{?settings.defaultPermissions.allowRead}{:else}
+	<p>This endpoint requires <a href="#authentication">authentication</a>.</p>
+{/settings.defaultPermissions.allowRead}
+
 <pre>{`{
 	result: {
 		// result entity
+	}
+}`}</pre>
+
+
+<h3><code>DELETE /api/v1/sites/<var>:siteId</var>/urls/<var>:urlId</var>/results/<var>:resultId</var></code></h3>
+
+<p>
+	Delete a <a href="#entities-result">result</a> by ID, returning JSON which outlines how many records were deleted.
+</p>
+
+{?settings.defaultPermissions.allowDelete}{:else}
+	<p>This endpoint requires <a href="#authentication">authentication</a>.</p>
+{/settings.defaultPermissions.allowDelete}
+
+<pre>{`{
+	deleted: {
+		results: 1
 	}
 }`}</pre>
 

--- a/view/api-v1.dust
+++ b/view/api-v1.dust
@@ -41,7 +41,7 @@
 </p>
 
 <p>
-	{?settings.defaultPermissions.allowWrite}{:else}
+	{^settings.defaultPermissions.allowWrite}
 		This endpoint requires <a href="#authentication">authentication</a>.{~s}
 	{/settings.defaultPermissions.allowWrite}
 	Expects the following JSON POST body:
@@ -58,7 +58,7 @@
 	Get a list of all <a href="#entities-site">sites</a> as a JSON array.
 </p>
 
-{?settings.defaultPermissions.allowRead}{:else}
+{^settings.defaultPermissions.allowRead}
 	<p>This endpoint requires <a href="#authentication">authentication</a>.</p>
 {/settings.defaultPermissions.allowRead}
 
@@ -80,7 +80,7 @@
 	Get a single <a href="#entities-site">site</a> as a JSON object.
 </p>
 
-{?settings.defaultPermissions.allowRead}{:else}
+{^settings.defaultPermissions.allowRead}
 	<p>This endpoint requires <a href="#authentication">authentication</a>.</p>
 {/settings.defaultPermissions.allowRead}
 
@@ -99,7 +99,7 @@
 </p>
 
 <p>
-	{?settings.defaultPermissions.allowWrite}{:else}
+	{^settings.defaultPermissions.allowWrite}
 		This endpoint requires <a href="#authentication">authentication</a>.{~s}
 	{/settings.defaultPermissions.allowWrite}
 	Expects the following JSON POST body:
@@ -118,7 +118,7 @@
 	returning JSON which outlines how many records were deleted.
 </p>
 
-{?settings.defaultPermissions.allowDelete}{:else}
+{^settings.defaultPermissions.allowDelete}
 	<p>This endpoint requires <a href="#authentication">authentication</a>.</p>
 {/settings.defaultPermissions.allowDelete}
 
@@ -137,7 +137,7 @@
 	Get a list of all site <a href="#entities-result">results</a> as a JSON array.
 </p>
 
-{?settings.defaultPermissions.allowRead}{:else}
+{^settings.defaultPermissions.allowRead}
 	<p>This endpoint requires <a href="#authentication">authentication</a>.</p>
 {/settings.defaultPermissions.allowRead}
 
@@ -161,7 +161,7 @@
 </p>
 
 <p>
-	{?settings.defaultPermissions.allowWrite}{:else}
+	{^settings.defaultPermissions.allowWrite}
 		This endpoint requires <a href="#authentication">authentication</a>.{~s}
 	{/settings.defaultPermissions.allowWrite}
 	Expects the following JSON POST body:
@@ -179,7 +179,7 @@
 	Get a list of all site <a href="#entities-url">URLs</a> as a JSON array.
 </p>
 
-{?settings.defaultPermissions.allowRead}{:else}
+{^settings.defaultPermissions.allowRead}
 	<p>This endpoint requires <a href="#authentication">authentication</a>.</p>
 {/settings.defaultPermissions.allowRead}
 
@@ -201,7 +201,7 @@
 	Get a single <a href="#entities-url">URL</a> as a JSON object.
 </p>
 
-{?settings.defaultPermissions.allowRead}{:else}
+{^settings.defaultPermissions.allowRead}
 	<p>This endpoint requires <a href="#authentication">authentication</a>.</p>
 {/settings.defaultPermissions.allowRead}
 
@@ -220,7 +220,7 @@
 </p>
 
 <p>
-	{?settings.defaultPermissions.allowWrite}{:else}
+	{^settings.defaultPermissions.allowWrite}
 		This endpoint requires <a href="#authentication">authentication</a>.{~s}
 	{/settings.defaultPermissions.allowWrite}
 	Expects the following JSON POST body:
@@ -240,7 +240,7 @@
 	returning JSON which outlines how many records were deleted.
 </p>
 
-{?settings.defaultPermissions.allowDelete}{:else}
+{^settings.defaultPermissions.allowDelete}
 	<p>This endpoint requires <a href="#authentication">authentication</a>.</p>
 {/settings.defaultPermissions.allowDelete}
 
@@ -258,7 +258,7 @@
 	Get a list of all URL <a href="#entities-result">results</a> as a JSON array.
 </p>
 
-{?settings.defaultPermissions.allowRead}{:else}
+{^settings.defaultPermissions.allowRead}
 	<p>This endpoint requires <a href="#authentication">authentication</a>.</p>
 {/settings.defaultPermissions.allowRead}
 
@@ -280,7 +280,7 @@
 	Get a single <a href="#entities-result">result</a> as a JSON object.
 </p>
 
-{?settings.defaultPermissions.allowRead}{:else}
+{^settings.defaultPermissions.allowRead}
 	<p>This endpoint requires <a href="#authentication">authentication</a>.</p>
 {/settings.defaultPermissions.allowRead}
 
@@ -297,7 +297,7 @@
 	Delete a <a href="#entities-result">result</a> by ID, returning JSON which outlines how many records were deleted.
 </p>
 
-{?settings.defaultPermissions.allowDelete}{:else}
+{^settings.defaultPermissions.allowDelete}
 	<p>This endpoint requires <a href="#authentication">authentication</a>.</p>
 {/settings.defaultPermissions.allowDelete}
 

--- a/view/partial/header.dust
+++ b/view/partial/header.dust
@@ -8,9 +8,13 @@
 		<nav>
 			<ul>
 
+				{! Key links !}
+				<li><a href="/">Dashboard</a></li>
+
 				{! User login/logout !}
 				{?user.isLoggedIn}
-					<li>Logged in as {user.email} (<a href="/logout">Logout</a>)</li>
+					<li><a href="/profile">Profile</a> ({user.email})</li>
+					<li><a href="/logout">Logout</a></li>
 				{:else}
 					<li><a href="/login">Login</a></li>
 				{/user.isLoggedIn}

--- a/view/profile.dust
+++ b/view/profile.dust
@@ -16,7 +16,7 @@
 
 	<form action="/profile/regenerate-api-key" method="post">
 		<p>
-			You can access the <a href="/api/v1">API for {appName}</a> using the key below:<br/>
+			You can access the <a href="/docs/api/v1">API for {appName}</a> using the key below:<br/>
 			<b><code>{user.apiKey}</code></b>
 		</p>
 		<p>

--- a/view/profile.dust
+++ b/view/profile.dust
@@ -1,0 +1,29 @@
+{>"layout/default"/}
+
+{<title}
+	Profile - {appName}
+{/title}
+
+{<content}
+
+	<h1>Profile</h1>
+
+	<p>
+		This is your user profile. Here you can update your preferences and manage access.
+	</p>
+
+	<h2>API Access</h2>
+
+	<form action="/profile/regenerate-api-key" method="post">
+		<p>
+			You can access the <a href="/api/v1">API for {appName}</a> using the key below:<br/>
+			<b><code>{user.apiKey}</code></b>
+		</p>
+		<p>
+			You can also regenerate this API key if it's accidentally leaked.{~s}
+			This will break any integrations that you have set up.{~s}
+			<input type="submit" value="Regenerate API Key"/>
+		</p>
+	</form>
+
+{/content}


### PR DESCRIPTION
I've added a profile page. It's only accessible when logged in, and you can only view the profile page of the currently logged in user.

This page doesn't do much yet. Eventually you'll be able to edit your email/password etc, but for now you can use it to view and regenerate your API key. This brings #11 one step closer to completion.

I've also updated the API documentation – it was out of date.

The profile page looks like this:

<pre><img alt="User profile page" src="https://cloud.githubusercontent.com/assets/138944/25890082/26e3f08c-3564-11e7-94f8-7d698f0e286a.png"></pre>
