### PR TITLE
Allow models to reject with multiple errors

### DIFF
--- a/controller/api/v1.js
+++ b/controller/api/v1.js
@@ -3,6 +3,7 @@
 const bodyParser = require('body-parser');
 const httpError = require('http-errors');
 const requirePermission = require('../../middleware/require-permission');
+const ValidationError = require('../../lib/validation-error');
 
 module.exports = dashboard => {
 	const app = dashboard.app;
@@ -23,7 +24,7 @@ module.exports = dashboard => {
 				response.send(response.locals);
 			})
 			.catch(error => {
-				if (error.isValidationError) {
+				if (error instanceof ValidationError) {
 					error.status = 400;
 				}
 				next(error);
@@ -67,7 +68,7 @@ module.exports = dashboard => {
 				response.send(response.locals);
 			})
 			.catch(error => {
-				if (error.isValidationError) {
+				if (error instanceof ValidationError) {
 					error.status = 400;
 				}
 				next(error);
@@ -106,7 +107,7 @@ module.exports = dashboard => {
 				response.send(response.locals);
 			})
 			.catch(error => {
-				if (error.isValidationError) {
+				if (error instanceof ValidationError) {
 					error.status = 400;
 				}
 				next(error);
@@ -172,7 +173,7 @@ module.exports = dashboard => {
 				response.send(response.locals);
 			})
 			.catch(error => {
-				if (error.isValidationError) {
+				if (error instanceof ValidationError) {
 					error.status = 400;
 				}
 				next(error);

--- a/controller/front-end/setup.js
+++ b/controller/front-end/setup.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const bodyParser = require('body-parser');
+const ValidationError = require('../../lib/validation-error');
 
 module.exports = dashboard => {
 	const app = dashboard.app;
@@ -66,7 +67,7 @@ module.exports = dashboard => {
 				response.redirect('/');
 			})
 			.catch(error => {
-				if (!error.isValidationError) {
+				if (!(error instanceof ValidationError)) {
 					return next(error);
 				}
 				response.status(400);

--- a/lib/validation-error.js
+++ b/lib/validation-error.js
@@ -1,0 +1,13 @@
+'use strict';
+
+// TODO the fact that we have this probably means we
+// should consider a third-party validation library –
+// the models are getting quite complex
+module.exports = class ValidationError extends Error {
+
+	constructor(message, validationMessages) {
+		super(message);
+		this.validationMessages = validationMessages || [];
+	}
+
+};

--- a/middleware/handle-errors.js
+++ b/middleware/handle-errors.js
@@ -60,6 +60,7 @@ function buildRenderContext(dashboard, error) {
 		error: {
 			status: statusCode,
 			message: error.message,
+			validationMessages: error.validationMessages,
 			stack: (dashboard.environment === 'development' ? error.stack : undefined)
 		}
 	};

--- a/model/user.js
+++ b/model/user.js
@@ -137,7 +137,7 @@ module.exports = dashboard => {
 			}
 
 			if (validationErrors.length) {
-				return Promise.reject(new ValidationError('Invalid URL data', validationErrors));
+				return Promise.reject(new ValidationError('Invalid user data', validationErrors));
 			}
 			const cleanData = {
 				email: data.email.trim(),

--- a/model/user.js
+++ b/model/user.js
@@ -4,6 +4,7 @@
 const bcrypt = require('bcrypt');
 const shortid = require('shortid');
 const uuid = require('uuid/v4');
+const ValidationError = require('../lib/validation-error');
 
 module.exports = dashboard => {
 	const database = dashboard.database;
@@ -97,43 +98,46 @@ module.exports = dashboard => {
 
 		// Validate/sanitize user data input
 		cleanInput(data) {
-			try {
-				if (typeof data !== 'object' || Array.isArray(data) || data === null) {
-					throw new Error('User should be an object');
-				}
+			const validationErrors = [];
+
+			// Validation
+			if (typeof data !== 'object' || Array.isArray(data) || data === null) {
+				validationErrors.push('User should be an object');
+			} else {
 				if (data.id) {
-					throw new Error('User ID cannot be set manually');
+					validationErrors.push('User ID cannot be set manually');
 				}
 				if (typeof data.email !== 'string' || !/^.+@.+$/.test(data.email)) {
-					throw new Error('User email should be a valid email address');
+					validationErrors.push('User email should be a valid email address');
 				}
 
 				// TODO ensure it's a good password
 				if (typeof data.password !== 'string') {
-					throw new Error('User password should be a string');
+					validationErrors.push('User password should be a string');
 				}
 				if (!data.password.trim()) {
-					throw new Error('User password cannot be empty');
+					validationErrors.push('User password cannot be empty');
 				}
 
 				if (data.apiKey) {
-					throw new Error('User API key cannot be set manually');
+					validationErrors.push('User API key cannot be set manually');
 				}
 				if (typeof data.allowRead !== 'boolean') {
-					throw new Error('User read permission should be a boolean');
+					validationErrors.push('User read permission should be a boolean');
 				}
 				if (typeof data.allowWrite !== 'boolean') {
-					throw new Error('User write permission should be a boolean');
+					validationErrors.push('User write permission should be a boolean');
 				}
 				if (typeof data.allowDelete !== 'boolean') {
-					throw new Error('User delete permission should be a boolean');
+					validationErrors.push('User delete permission should be a boolean');
 				}
 				if (typeof data.allowAdmin !== 'boolean') {
-					throw new Error('User admin permission should be a boolean');
+					validationErrors.push('User admin permission should be a boolean');
 				}
-			} catch (error) {
-				error.isValidationError = true;
-				return Promise.reject(error);
+			}
+
+			if (validationErrors.length) {
+				return Promise.reject(new ValidationError('Invalid URL data', validationErrors));
 			}
 			const cleanData = {
 				email: data.email.trim(),
@@ -196,8 +200,9 @@ module.exports = dashboard => {
 		},
 
 		_rawGetByEmailAndPassword(email, password) {
-			const error = new Error('Incorrect email or password');
-			error.isValidationError = true;
+			const error = new ValidationError('Invalid login', [
+				'Incorrect email or password'
+			]);
 
 			return database
 				.select('*')

--- a/test/integration/api/v1/patch-sites-id-urls-id.js
+++ b/test/integration/api/v1/patch-sites-id-urls-id.js
@@ -111,7 +111,10 @@ describe('PATCH /api/v1/sites/:siteId/urls/:urlId', () => {
 		it('responds with an error message', done => {
 			request.expect({
 				error: {
-					message: 'URL should be an object',
+					message: 'Invalid URL data',
+					validationMessages: [
+						'URL should be an object'
+					],
 					status: 400
 				}
 			}).end(done);
@@ -136,7 +139,10 @@ describe('PATCH /api/v1/sites/:siteId/urls/:urlId', () => {
 		it('responds with an error message', done => {
 			request.expect({
 				error: {
-					message: 'URL name should be a string',
+					message: 'Invalid URL data',
+					validationMessages: [
+						'URL name should be a string'
+					],
 					status: 400
 				}
 			}).end(done);
@@ -161,7 +167,10 @@ describe('PATCH /api/v1/sites/:siteId/urls/:urlId', () => {
 		it('responds with an error message', done => {
 			request.expect({
 				error: {
-					message: 'URL name cannot be empty',
+					message: 'Invalid URL data',
+					validationMessages: [
+						'URL name cannot be empty'
+					],
 					status: 400
 				}
 			}).end(done);
@@ -186,7 +195,10 @@ describe('PATCH /api/v1/sites/:siteId/urls/:urlId', () => {
 		it('responds with an error message', done => {
 			request.expect({
 				error: {
-					message: 'URL address should be a string',
+					message: 'Invalid URL data',
+					validationMessages: [
+						'URL address should be a string'
+					],
 					status: 400
 				}
 			}).end(done);
@@ -211,7 +223,10 @@ describe('PATCH /api/v1/sites/:siteId/urls/:urlId', () => {
 		it('responds with an error message', done => {
 			request.expect({
 				error: {
-					message: 'URL address cannot be empty',
+					message: 'Invalid URL data',
+					validationMessages: [
+						'URL address cannot be empty'
+					],
 					status: 400
 				}
 			}).end(done);
@@ -236,7 +251,10 @@ describe('PATCH /api/v1/sites/:siteId/urls/:urlId', () => {
 		it('responds with an error message', done => {
 			request.expect({
 				error: {
-					message: 'URL ID cannot be set manually',
+					message: 'Invalid URL data',
+					validationMessages: [
+						'URL ID cannot be set manually'
+					],
 					status: 400
 				}
 			}).end(done);

--- a/test/integration/api/v1/patch-sites-id.js
+++ b/test/integration/api/v1/patch-sites-id.js
@@ -123,7 +123,10 @@ describe('PATCH /api/v1/sites/:siteId', () => {
 		it('responds with an error message', done => {
 			request.expect({
 				error: {
-					message: 'Site should be an object',
+					message: 'Invalid site data',
+					validationMessages: [
+						'Site should be an object'
+					],
 					status: 400
 				}
 			}).end(done);
@@ -148,7 +151,10 @@ describe('PATCH /api/v1/sites/:siteId', () => {
 		it('responds with an error message', done => {
 			request.expect({
 				error: {
-					message: 'Site name should be a string',
+					message: 'Invalid site data',
+					validationMessages: [
+						'Site name should be a string'
+					],
 					status: 400
 				}
 			}).end(done);
@@ -173,7 +179,10 @@ describe('PATCH /api/v1/sites/:siteId', () => {
 		it('responds with an error message', done => {
 			request.expect({
 				error: {
-					message: 'Site name cannot be empty',
+					message: 'Invalid site data',
+					validationMessages: [
+						'Site name cannot be empty'
+					],
 					status: 400
 				}
 			}).end(done);
@@ -198,7 +207,10 @@ describe('PATCH /api/v1/sites/:siteId', () => {
 		it('responds with an error message', done => {
 			request.expect({
 				error: {
-					message: 'Site ID cannot be set manually',
+					message: 'Invalid site data',
+					validationMessages: [
+						'Site ID cannot be set manually'
+					],
 					status: 400
 				}
 			}).end(done);

--- a/test/integration/api/v1/post-sites-id-urls.js
+++ b/test/integration/api/v1/post-sites-id-urls.js
@@ -118,7 +118,10 @@ describe('POST /api/v1/sites/:siteId/urls', () => {
 		it('responds with an error message', done => {
 			request.expect({
 				error: {
-					message: 'URL should be an object',
+					message: 'Invalid URL data',
+					validationMessages: [
+						'URL should be an object'
+					],
 					status: 400
 				}
 			}).end(done);
@@ -143,7 +146,10 @@ describe('POST /api/v1/sites/:siteId/urls', () => {
 		it('responds with an error message', done => {
 			request.expect({
 				error: {
-					message: 'URL name should be a string',
+					message: 'Invalid URL data',
+					validationMessages: [
+						'URL name should be a string'
+					],
 					status: 400
 				}
 			}).end(done);
@@ -168,7 +174,10 @@ describe('POST /api/v1/sites/:siteId/urls', () => {
 		it('responds with an error message', done => {
 			request.expect({
 				error: {
-					message: 'URL name cannot be empty',
+					message: 'Invalid URL data',
+					validationMessages: [
+						'URL name cannot be empty'
+					],
 					status: 400
 				}
 			}).end(done);
@@ -193,7 +202,10 @@ describe('POST /api/v1/sites/:siteId/urls', () => {
 		it('responds with an error message', done => {
 			request.expect({
 				error: {
-					message: 'URL address should be a string',
+					message: 'Invalid URL data',
+					validationMessages: [
+						'URL address should be a string'
+					],
 					status: 400
 				}
 			}).end(done);
@@ -218,7 +230,10 @@ describe('POST /api/v1/sites/:siteId/urls', () => {
 		it('responds with an error message', done => {
 			request.expect({
 				error: {
-					message: 'URL address cannot be empty',
+					message: 'Invalid URL data',
+					validationMessages: [
+						'URL address cannot be empty'
+					],
 					status: 400
 				}
 			}).end(done);
@@ -243,7 +258,10 @@ describe('POST /api/v1/sites/:siteId/urls', () => {
 		it('responds with an error message', done => {
 			request.expect({
 				error: {
-					message: 'URL ID cannot be set manually',
+					message: 'Invalid URL data',
+					validationMessages: [
+						'URL ID cannot be set manually'
+					],
 					status: 400
 				}
 			}).end(done);

--- a/test/integration/api/v1/post-sites.js
+++ b/test/integration/api/v1/post-sites.js
@@ -113,7 +113,10 @@ describe('POST /api/v1/sites', () => {
 		it('responds with an error message', done => {
 			request.expect({
 				error: {
-					message: 'Site should be an object',
+					message: 'Invalid site data',
+					validationMessages: [
+						'Site should be an object'
+					],
 					status: 400
 				}
 			}).end(done);
@@ -138,7 +141,10 @@ describe('POST /api/v1/sites', () => {
 		it('responds with an error message', done => {
 			request.expect({
 				error: {
-					message: 'Site name should be a string',
+					message: 'Invalid site data',
+					validationMessages: [
+						'Site name should be a string'
+					],
 					status: 400
 				}
 			}).end(done);
@@ -163,7 +169,10 @@ describe('POST /api/v1/sites', () => {
 		it('responds with an error message', done => {
 			request.expect({
 				error: {
-					message: 'Site name cannot be empty',
+					message: 'Invalid site data',
+					validationMessages: [
+						'Site name cannot be empty'
+					],
 					status: 400
 				}
 			}).end(done);
@@ -188,7 +197,10 @@ describe('POST /api/v1/sites', () => {
 		it('responds with an error message', done => {
 			request.expect({
 				error: {
-					message: 'Site ID cannot be set manually',
+					message: 'Invalid site data',
+					validationMessages: [
+						'Site ID cannot be set manually'
+					],
 					status: 400
 				}
 			}).end(done);

--- a/test/unit/lib/validation-error.js
+++ b/test/unit/lib/validation-error.js
@@ -1,0 +1,64 @@
+/* eslint max-len: 'off' */
+'use strict';
+
+const assert = require('proclaim');
+const sinon = require('sinon');
+
+describe('lib/validation-error', () => {
+	let ValidationError;
+
+	beforeEach(() => {
+		ValidationError = require('../../../lib/validation-error');
+	});
+
+	it('exports a function', () => {
+		assert.isFunction(ValidationError);
+	});
+
+	describe('new ValidationError(message)', () => {
+		let instance;
+
+		beforeEach(() => {
+			instance = new ValidationError('mock-message');
+		});
+
+		it('extends Error', () => {
+			assert.instanceOf(instance, Error);
+		});
+
+		it('has a `message` property set to `message`', () => {
+			assert.strictEqual(instance.message, 'mock-message');
+		});
+
+		it('has a `validationMessages` property set to an empty array', () => {
+			assert.deepEqual(instance.validationMessages, []);
+		});
+
+	});
+
+	describe('new ValidationError(message, validationMessages)', () => {
+		let instance;
+
+		beforeEach(() => {
+			instance = new ValidationError('mock-message', [
+				'mock-validation-message'
+			]);
+		});
+
+		it('extends Error', () => {
+			assert.instanceOf(instance, Error);
+		});
+
+		it('has a `message` property set to `message`', () => {
+			assert.strictEqual(instance.message, 'mock-message');
+		});
+
+		it('has a `validationMessages` property set to `validationMessages`', () => {
+			assert.deepEqual(instance.validationMessages, [
+				'mock-validation-message'
+			]);
+		});
+
+	});
+
+});

--- a/test/unit/lib/validation-error.js
+++ b/test/unit/lib/validation-error.js
@@ -2,7 +2,6 @@
 'use strict';
 
 const assert = require('proclaim');
-const sinon = require('sinon');
 
 describe('lib/validation-error', () => {
 	let ValidationError;

--- a/test/unit/middleware/handle-errors.js
+++ b/test/unit/middleware/handle-errors.js
@@ -56,6 +56,7 @@ describe('middleware/handle-errors', () => {
 				assert.calledWith(express.mockResponse.render, 'error', {
 					error: {
 						message: error.message,
+						validationMessages: undefined,
 						status: error.status,
 						stack: undefined
 					}
@@ -111,6 +112,7 @@ describe('middleware/handle-errors', () => {
 					assert.calledWith(express.mockResponse.render, 'error', {
 						error: {
 							message: error.message,
+							validationMessages: undefined,
 							status: error.status,
 							stack: error.stack
 						}
@@ -145,6 +147,30 @@ describe('middleware/handle-errors', () => {
 				it('sets the response status to 500', () => {
 					assert.calledOnce(express.mockResponse.status);
 					assert.calledWithExactly(express.mockResponse.status, 500);
+				});
+
+			});
+
+			describe('when the error has a `validationMessages` property', () => {
+
+				beforeEach(() => {
+					error.validationMessages = [
+						'mock-validation-message'
+					];
+					express.mockResponse.render.reset();
+					middleware(error, express.mockRequest, express.mockResponse, next);
+				});
+
+				it('includes the validation messages when rendering the error template', () => {
+					assert.calledOnce(express.mockResponse.render);
+					assert.calledWith(express.mockResponse.render, 'error', {
+						error: {
+							message: error.message,
+							validationMessages: error.validationMessages,
+							status: error.status,
+							stack: undefined
+						}
+					});
 				});
 
 			});
@@ -225,6 +251,7 @@ describe('middleware/handle-errors', () => {
 				assert.calledWithExactly(express.mockResponse.send, {
 					error: {
 						message: error.message,
+						validationMessages: undefined,
 						status: error.status,
 						stack: undefined
 					}
@@ -270,6 +297,7 @@ describe('middleware/handle-errors', () => {
 					assert.calledWithExactly(express.mockResponse.send, {
 						error: {
 							message: error.message,
+							validationMessages: undefined,
 							status: error.status,
 							stack: error.stack
 						}
@@ -289,6 +317,30 @@ describe('middleware/handle-errors', () => {
 				it('sets the response status to 500', () => {
 					assert.calledOnce(express.mockResponse.status);
 					assert.calledWithExactly(express.mockResponse.status, 500);
+				});
+
+			});
+
+			describe('when the error has a `validationMessages` property', () => {
+
+				beforeEach(() => {
+					error.validationMessages = [
+						'mock-validation-message'
+					];
+					express.mockResponse.send.reset();
+					middleware(error, express.mockRequest, express.mockResponse, next);
+				});
+
+				it('includes the validation messages when rendering the error template', () => {
+					assert.calledOnce(express.mockResponse.send);
+					assert.calledWith(express.mockResponse.send, {
+						error: {
+							message: error.message,
+							validationMessages: error.validationMessages,
+							status: error.status,
+							stack: undefined
+						}
+					});
 				});
 
 			});

--- a/view/login.dust
+++ b/view/login.dust
@@ -13,7 +13,16 @@
 
 		{?error}
 			<output name="error" class="form-error">
-				There was an error logging in: {error.message}
+				<p>There was an error logging in:</p>
+				{?error.validationMessages}
+					<ul>
+						{#error.validationMessages}
+							<li>{.}</li>
+						{/error.validationMessages}
+					</ul>
+				{:else}
+					<p>{error.message}</p>
+				{/error.validationMessages}
 			</output>
 		{/error}
 

--- a/view/setup.dust
+++ b/view/setup.dust
@@ -17,7 +17,16 @@
 
 		{?error}
 			<output name="error" class="form-error">
-				There was an error setting up {appName}: {error.message}
+				<p>There was an error setting up {appName}:</p>
+				{?error.validationMessages}
+					<ul>
+						{#error.validationMessages}
+							<li>{.}</li>
+						{/error.validationMessages}
+					</ul>
+				{:else}
+					<p>{error.message}</p>
+				{/error.validationMessages}
 			</output>
 		{/error}
 


### PR DESCRIPTION
This means we can display everything that's wrong with a form
submission, rather than just one error at a time. This will do for now,
but this work probably indicates that we need to look into using a
third-party validation library.