### PR TITLE
Overhaul the integration tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -449,7 +449,7 @@
       "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
       "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
       "requires": {
-        "hoek": "4.2.0"
+        "hoek": "4.2.1"
       }
     },
     "boxen": {
@@ -721,9 +721,9 @@
       "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
     },
     "combined-stream": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-      "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+      "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
       "requires": {
         "delayed-stream": "1.0.0"
       }
@@ -732,12 +732,6 @@
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
       "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
-    },
-    "component-emitter": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-      "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
-      "dev": true
     },
     "compressible": {
       "version": "2.0.12",
@@ -827,12 +821,6 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
-    "cookiejar": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.1.tgz",
-      "integrity": "sha1-Qa1XsbVVlR7BcUEqgZQrHoIA00o=",
-      "dev": true
-    },
     "core-js": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
@@ -886,7 +874,7 @@
           "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
           "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
           "requires": {
-            "hoek": "4.2.0"
+            "hoek": "4.2.1"
           }
         }
       }
@@ -1634,12 +1622,12 @@
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
     },
     "form-data": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
-      "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+      "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
       "requires": {
         "asynckit": "0.4.0",
-        "combined-stream": "1.0.5",
+        "combined-stream": "1.0.6",
         "mime-types": "2.1.17"
       }
     },
@@ -1651,12 +1639,6 @@
       "requires": {
         "samsam": "1.3.0"
       }
-    },
-    "formidable": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.1.1.tgz",
-      "integrity": "sha1-lriIb3w8NQi5Mta9cMTTqI818ak=",
-      "dev": true
     },
     "forwarded": {
       "version": "0.1.2",
@@ -2808,7 +2790,7 @@
       "requires": {
         "boom": "4.3.1",
         "cryptiles": "3.1.2",
-        "hoek": "4.2.0",
+        "hoek": "4.2.1",
         "sntp": "2.1.0"
       }
     },
@@ -2819,9 +2801,9 @@
       "dev": true
     },
     "hoek": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
-      "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ=="
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
+      "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
     },
     "homedir-polyfill": {
       "version": "1.0.1",
@@ -6405,10 +6387,10 @@
         "aws-sign2": "0.7.0",
         "aws4": "1.6.0",
         "caseless": "0.12.0",
-        "combined-stream": "1.0.5",
+        "combined-stream": "1.0.6",
         "extend": "3.0.1",
         "forever-agent": "0.6.1",
-        "form-data": "2.3.1",
+        "form-data": "2.3.2",
         "har-validator": "5.0.3",
         "hawk": "6.0.2",
         "http-signature": "1.2.0",
@@ -6705,7 +6687,7 @@
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
       "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
       "requires": {
-        "hoek": "4.2.0"
+        "hoek": "4.2.1"
       }
     },
     "source-map": {
@@ -6810,45 +6792,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
-    },
-    "superagent": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.1.tgz",
-      "integrity": "sha512-VMBFLYgFuRdfeNQSMLbxGSLfmXL/xc+OO+BZp41Za/NRDBet/BNbkRJrYzCUu0u4GU0i/ml2dtT8b9qgkw9z6Q==",
-      "dev": true,
-      "requires": {
-        "component-emitter": "1.2.1",
-        "cookiejar": "2.1.1",
-        "debug": "3.1.0",
-        "extend": "3.0.1",
-        "form-data": "2.3.1",
-        "formidable": "1.1.1",
-        "methods": "1.1.2",
-        "mime": "1.4.1",
-        "qs": "6.5.1",
-        "readable-stream": "2.3.3"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
-      }
-    },
-    "supertest": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/supertest/-/supertest-3.0.0.tgz",
-      "integrity": "sha1-jUu2j9GDDuBwM7HFpamkAhyWUpY=",
-      "dev": true,
-      "requires": {
-        "methods": "1.1.2",
-        "superagent": "3.8.1"
-      }
     },
     "supports-color": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -50,8 +50,9 @@
     "nodemon": "^1.12.1",
     "nyc": "^11.3.0",
     "proclaim": "^3.5.0",
-    "sinon": "^4.1.2",
-    "supertest": "^3.0.0"
+    "request": "^2.83.0",
+    "request-promise-native": "^1.0.5",
+    "sinon": "^4.1.2"
   },
   "optionalDependencies": {
     "fsevents": "^1.1.3"

--- a/test/integration/.eslintrc.js
+++ b/test/integration/.eslintrc.js
@@ -2,7 +2,7 @@
 
 module.exports = {
 	globals: {
-		agent: true,
-		dashboard: true
+		dashboard: true,
+		request: true
 	}
 };

--- a/test/integration/helpers/auth.js
+++ b/test/integration/helpers/auth.js
@@ -1,17 +1,18 @@
 'use strict';
 
-// Log into the site
-async function login(email, password) {
-	await agent
-		.post('/login')
-		.set('Content-Type', 'application/x-www-form-urlencoded')
-		.send({
-			email,
-			password
-		})
-		.then();
+// Log into the site and get a cookie jar
+async function getCookieJar(email, password) {
+	const jar = request.jar();
+	await request.post('/login', {
+		headers: {
+			'Content-Type': 'application/x-www-form-urlencoded'
+		},
+		body: `email=${email}&password=${password}`,
+		jar
+	});
+	return jar;
 }
 
 module.exports = {
-	login: login
+	getCookieJar: getCookieJar
 };

--- a/test/integration/routes/api-v1/index.test.js
+++ b/test/integration/routes/api-v1/index.test.js
@@ -1,25 +1,30 @@
 'use strict';
 
+const assert = require('proclaim');
 const database = require('../../helpers/database');
+let response;
 
 describe('GET /api/v1', () => {
-	let request;
 
-	beforeEach(async () => {
-		await database.seed(dashboard, 'basic');
-		request = agent.get('/api/v1');
-	});
+	describe('when everything is valid', () => {
 
-	it('responds with a 302 status', () => {
-		return request.expect(302);
-	});
+		before(async () => {
+			await database.seed(dashboard, 'basic');
+			response = await request.get('/api/v1');
+		});
 
-	it('responds with a Location header pointing to the API documentation page', () => {
-		return request.expect('Location', '/docs/api/v1');
-	});
+		it('responds with a 302 status', () => {
+			assert.strictEqual(response.statusCode, 302);
+		});
 
-	it('responds with plain text', () => {
-		return request.expect('Content-Type', /text\/plain/);
+		it('responds with a Location header pointing to the API documentation page', () => {
+			assert.strictEqual(response.headers.location, '/docs/api/v1');
+		});
+
+		it('responds with plain text', () => {
+			assert.include(response.headers['content-type'], 'text/plain');
+		});
+
 	});
 
 });

--- a/test/integration/routes/api-v1/me-keys-(id).test.js
+++ b/test/integration/routes/api-v1/me-keys-(id).test.js
@@ -1,120 +1,114 @@
 'use strict';
 
-const database = require('../../helpers/database');
 const assert = require('proclaim');
+const database = require('../../helpers/database');
+let response;
 
 describe('GET /api/v1/me/keys/:keyId', () => {
-	let request;
+
+	before(async () => {
+		await database.seed(dashboard, 'basic');
+	});
 
 	describe('when everything is valid', () => {
 
-		beforeEach(async () => {
-			await database.seed(dashboard, 'basic');
-			request = agent
-				.get('/api/v1/me/keys/mock-read-key')
-				.set('X-Api-Key', 'mock-read-key')
-				.set('X-Api-Secret', 'mock-read-secret');
+		before(async () => {
+			response = await request.get('/api/v1/me/keys/mock-read-key', {
+				headers: {
+					'X-Api-Key': 'mock-read-key',
+					'X-Api-Secret': 'mock-read-secret'
+				}
+			});
 		});
 
 		it('responds with a 200 status', () => {
-			return request.expect(200);
+			assert.strictEqual(response.statusCode, 200);
 		});
 
 		it('responds with JSON', () => {
-			return request.expect('Content-Type', /application\/json/);
+			assert.include(response.headers['content-type'], 'application/json');
 		});
 
-		describe('JSON response', () => {
-			it('contains the key details', async () => {
-				const json = (await request.then()).body;
-				assert.isObject(json);
-				assert.strictEqual(json.id, 'mock-read-key');
-				assert.strictEqual(json.user, 'mock-read-id');
-			});
+		it('responds with the key details', () => {
+			assert.isObject(response.body);
+			assert.strictEqual(response.body.id, 'mock-read-key');
+			assert.strictEqual(response.body.user, 'mock-read-id');
 		});
 
 	});
 
 	describe('when :keyId is not a valid key ID', () => {
 
-		beforeEach(async () => {
-			await database.seed(dashboard, 'basic');
-			request = agent
-				.get('/api/v1/me/keys/not-an-id')
-				.set('X-Api-Key', 'mock-read-key')
-				.set('X-Api-Secret', 'mock-read-secret');
+		before(async () => {
+			response = await request.get('/api/v1/me/keys/not-an-id', {
+				headers: {
+					'X-Api-Key': 'mock-read-key',
+					'X-Api-Secret': 'mock-read-secret'
+				}
+			});
 		});
 
 		it('responds with a 404 status', () => {
-			return request.expect(404);
+			assert.strictEqual(response.statusCode, 404);
 		});
 
 		it('responds with JSON', () => {
-			return request.expect('Content-Type', /application\/json/);
+			assert.include(response.headers['content-type'], 'application/json');
 		});
 
-		describe('JSON response', () => {
-			it('contains error details', async () => {
-				const json = (await request.then()).body;
-				assert.isObject(json);
-				assert.isString(json.message);
-				assert.strictEqual(json.status, 404);
-			});
+		it('responds with error details', () => {
+			assert.isObject(response.body);
+			assert.isString(response.body.message);
+			assert.strictEqual(response.body.status, 404);
 		});
 
 	});
 
 	describe('when the key does not belong to the currently authenticated user', () => {
 
-		beforeEach(async () => {
-			await database.seed(dashboard, 'basic');
-			request = agent
-				.get('/api/v1/me/keys/mock-write-key')
-				.set('X-Api-Key', 'mock-read-key')
-				.set('X-Api-Secret', 'mock-read-secret');
+		before(async () => {
+			response = await request.get('/api/v1/me/keys/mock-write-key', {
+				headers: {
+					'X-Api-Key': 'mock-read-key',
+					'X-Api-Secret': 'mock-read-secret'
+				}
+			});
 		});
 
 		it('responds with a 404 status', () => {
-			return request.expect(404);
+			assert.strictEqual(response.statusCode, 404);
 		});
 
 		it('responds with JSON', () => {
-			return request.expect('Content-Type', /application\/json/);
+			assert.include(response.headers['content-type'], 'application/json');
 		});
 
-		describe('JSON response', () => {
-			it('contains error details', async () => {
-				const json = (await request.then()).body;
-				assert.isObject(json);
-				assert.isString(json.message);
-				assert.strictEqual(json.status, 404);
-			});
+		it('responds with error details', () => {
+			assert.isObject(response.body);
+			assert.isString(response.body.message);
+			assert.strictEqual(response.body.status, 404);
 		});
 
 	});
 
 	describe('when no API credentials are provided', () => {
 
-		beforeEach(async () => {
-			await database.seed(dashboard, 'basic');
-			request = agent.get('/api/v1/me/keys/mock-read-key');
+		before(async () => {
+			response = await request.get('/api/v1/me/keys/mock-read-key');
 		});
 
 		it('responds with a 401 status', () => {
-			return request.expect(401);
+			assert.strictEqual(response.statusCode, 401);
 		});
 
 		it('responds with JSON', () => {
-			return request.expect('Content-Type', /application\/json/);
+			assert.include(response.headers['content-type'], 'application/json');
 		});
 
-		describe('JSON response', () => {
-			it('contains error details', async () => {
-				const json = (await request.then()).body;
-				assert.isObject(json);
-				assert.isString(json.message);
-				assert.strictEqual(json.status, 401);
-			});
+		it('responds with error details', () => {
+			assert.isObject(response.body);
+			assert.isString(response.body.message);
+			assert.strictEqual(response.body.status, 401);
 		});
 
 	});
@@ -122,31 +116,31 @@ describe('GET /api/v1/me/keys/:keyId', () => {
 });
 
 describe('PATCH /api/v1/me/keys/:keyId', () => {
-	let request;
 
 	describe('when everything is valid', () => {
 
-		beforeEach(async () => {
+		before(async () => {
 			await database.seed(dashboard, 'basic');
-			request = agent
-				.patch('/api/v1/me/keys/mock-read-key')
-				.set('X-Api-Key', 'mock-read-key')
-				.set('X-Api-Secret', 'mock-read-secret')
-				.send({
+			response = await request.patch('/api/v1/me/keys/mock-read-key', {
+				headers: {
+					'Content-Type': 'application/json',
+					'X-Api-Key': 'mock-read-key',
+					'X-Api-Secret': 'mock-read-secret'
+				},
+				body: JSON.stringify({
 					id: 'extra-property-id',
 					secret: 'extra-property-secret',
 					user_id: 'extra-property-user-id',
 					description: 'new-description'
-				});
+				})
+			});
 		});
 
 		it('updates the key in the database', async () => {
-			await request.then();
 			const keys = await dashboard.database.knex.select('*').from('keys').where({
 				description: 'new-description'
 			});
 			const key = keys[0];
-
 			assert.lengthEquals(keys, 1, 'One key is present');
 			assert.notStrictEqual(key.id, 'extra-property-id', 'Key ID cannot be set in request');
 			assert.notStrictEqual(key.secret, 'extra-property-secret', 'Key secret cannot be set in request');
@@ -155,168 +149,168 @@ describe('PATCH /api/v1/me/keys/:keyId', () => {
 		});
 
 		it('responds with a 200 status', () => {
-			return request.expect(200);
+			assert.strictEqual(response.statusCode, 200);
 		});
 
 		it('responds with JSON', () => {
-			return request.expect('Content-Type', /application\/json/);
+			assert.include(response.headers['content-type'], 'application/json');
 		});
 
-		describe('JSON response', () => {
-			it('contains the updated key details', async () => {
-				const json = (await request.then()).body;
-				assert.isObject(json);
-				assert.strictEqual(json.id, 'mock-read-key');
-				assert.strictEqual(json.user, 'mock-read-id');
-				assert.strictEqual(json.description, 'new-description');
-			});
+		it('responds with the updated key details', () => {
+			assert.isObject(response.body);
+			assert.strictEqual(response.body.id, 'mock-read-key');
+			assert.strictEqual(response.body.user, 'mock-read-id');
+			assert.strictEqual(response.body.description, 'new-description');
 		});
 
 	});
 
 	describe('when the request has no data set', () => {
 
-		beforeEach(async () => {
+		before(async () => {
 			await database.seed(dashboard, 'basic');
-			request = agent
-				.patch('/api/v1/me/keys/mock-read-key')
-				.set('X-Api-Key', 'mock-read-key')
-				.set('X-Api-Secret', 'mock-read-secret')
-				.send({});
+			response = await request.patch('/api/v1/me/keys/mock-read-key', {
+				headers: {
+					'Content-Type': 'application/json',
+					'X-Api-Key': 'mock-read-key',
+					'X-Api-Secret': 'mock-read-secret'
+				},
+				body: JSON.stringify({})
+			});
 		});
 
 		it('responds with a 200 status', () => {
-			return request.expect(200);
+			assert.strictEqual(response.statusCode, 200);
 		});
 
 	});
 
 	describe('when the request includes an invalid description property', () => {
 
-		beforeEach(async () => {
+		before(async () => {
 			await database.seed(dashboard, 'basic');
-			request = agent
-				.patch('/api/v1/me/keys/mock-read-key')
-				.set('X-Api-Key', 'mock-read-key')
-				.set('X-Api-Secret', 'mock-read-secret')
-				.send({
+			response = await request.patch('/api/v1/me/keys/mock-read-key', {
+				headers: {
+					'Content-Type': 'application/json',
+					'X-Api-Key': 'mock-read-key',
+					'X-Api-Secret': 'mock-read-secret'
+				},
+				body: JSON.stringify({
 					description: []
-				});
+				})
+			});
 		});
 
 		it('responds with a 400 status', () => {
-			return request.expect(400);
+			assert.strictEqual(response.statusCode, 400);
 		});
 
 		it('responds with JSON', () => {
-			return request.expect('Content-Type', /application\/json/);
+			assert.include(response.headers['content-type'], 'application/json');
 		});
 
-		describe('JSON response', () => {
-			it('contains error details', async () => {
-				const json = (await request.then()).body;
-				assert.isObject(json);
-				assert.isString(json.message, 'Validation failed');
-				assert.isArray(json.validation);
-				assert.deepEqual(json.validation, [
-					'"description" must be a string'
-				]);
-				assert.strictEqual(json.status, 400);
-			});
+		it('responds with error details', () => {
+			assert.isObject(response.body);
+			assert.isString(response.body.message, 'Validation failed');
+			assert.isArray(response.body.validation);
+			assert.deepEqual(response.body.validation, [
+				'"description" must be a string'
+			]);
+			assert.strictEqual(response.body.status, 400);
 		});
 
 	});
 
 	describe('when :keyId is not a valid key ID', () => {
 
-		beforeEach(async () => {
+		before(async () => {
 			await database.seed(dashboard, 'basic');
-			request = agent
-				.patch('/api/v1/me/keys/not-an-id')
-				.set('X-Api-Key', 'mock-read-key')
-				.set('X-Api-Secret', 'mock-read-secret')
-				.send({
+			response = await request.patch('/api/v1/me/keys/not-an-id', {
+				headers: {
+					'Content-Type': 'application/json',
+					'X-Api-Key': 'mock-read-key',
+					'X-Api-Secret': 'mock-read-secret'
+				},
+				body: JSON.stringify({
 					description: 'new-description'
-				});
+				})
+			});
 		});
 
 		it('responds with a 404 status', () => {
-			return request.expect(404);
+			assert.strictEqual(response.statusCode, 404);
 		});
 
 		it('responds with JSON', () => {
-			return request.expect('Content-Type', /application\/json/);
+			assert.include(response.headers['content-type'], 'application/json');
 		});
 
-		describe('JSON response', () => {
-			it('contains error details', async () => {
-				const json = (await request.then()).body;
-				assert.isObject(json);
-				assert.isString(json.message);
-				assert.strictEqual(json.status, 404);
-			});
+		it('responds with error details', () => {
+			assert.isObject(response.body);
+			assert.isString(response.body.message);
+			assert.strictEqual(response.body.status, 404);
 		});
 
 	});
 
 	describe('when the key does not belong to the currently authenticated user', () => {
 
-		beforeEach(async () => {
+		before(async () => {
 			await database.seed(dashboard, 'basic');
-			request = agent
-				.patch('/api/v1/me/keys/mock-write-key')
-				.set('X-Api-Key', 'mock-read-key')
-				.set('X-Api-Secret', 'mock-read-secret')
-				.send({
+			response = await request.patch('/api/v1/me/keys/mock-write-key', {
+				headers: {
+					'Content-Type': 'application/json',
+					'X-Api-Key': 'mock-read-key',
+					'X-Api-Secret': 'mock-read-secret'
+				},
+				body: JSON.stringify({
 					description: 'new-description'
-				});
+				})
+			});
 		});
 
 		it('responds with a 404 status', () => {
-			return request.expect(404);
+			assert.strictEqual(response.statusCode, 404);
 		});
 
 		it('responds with JSON', () => {
-			return request.expect('Content-Type', /application\/json/);
+			assert.include(response.headers['content-type'], 'application/json');
 		});
 
-		describe('JSON response', () => {
-			it('contains error details', async () => {
-				const json = (await request.then()).body;
-				assert.isObject(json);
-				assert.isString(json.message);
-				assert.strictEqual(json.status, 404);
-			});
+		it('responds with error details', () => {
+			assert.isObject(response.body);
+			assert.isString(response.body.message);
+			assert.strictEqual(response.body.status, 404);
 		});
 
 	});
 
 	describe('when no API credentials are provided', () => {
 
-		beforeEach(async () => {
+		before(async () => {
 			await database.seed(dashboard, 'basic');
-			request = agent
-				.patch('/api/v1/me/keys/mock-read-key')
-				.send({
+			response = await request.patch('/api/v1/me/keys/mock-read-key', {
+				headers: {
+					'Content-Type': 'application/json'
+				},
+				body: JSON.stringify({
 					description: 'new-description'
-				});
+				})
+			});
 		});
 
 		it('responds with a 401 status', () => {
-			return request.expect(401);
+			assert.strictEqual(response.statusCode, 401);
 		});
 
 		it('responds with JSON', () => {
-			return request.expect('Content-Type', /application\/json/);
+			assert.include(response.headers['content-type'], 'application/json');
 		});
 
-		describe('JSON response', () => {
-			it('contains error details', async () => {
-				const json = (await request.then()).body;
-				assert.isObject(json);
-				assert.isString(json.message);
-				assert.strictEqual(json.status, 401);
-			});
+		it('responds with error details', () => {
+			assert.isObject(response.body);
+			assert.isString(response.body.message);
+			assert.strictEqual(response.body.status, 401);
 		});
 
 	});
@@ -324,20 +318,20 @@ describe('PATCH /api/v1/me/keys/:keyId', () => {
 });
 
 describe('DELETE /api/v1/me/keys/:keyId', () => {
-	let request;
 
 	describe('when everything is valid', () => {
 
-		beforeEach(async () => {
+		before(async () => {
 			await database.seed(dashboard, 'basic');
-			request = agent
-				.delete('/api/v1/me/keys/mock-read-key-2')
-				.set('X-Api-Key', 'mock-read-key')
-				.set('X-Api-Secret', 'mock-read-secret');
+			response = await request.delete('/api/v1/me/keys/mock-read-key-2', {
+				headers: {
+					'X-Api-Key': 'mock-read-key',
+					'X-Api-Secret': 'mock-read-secret'
+				}
+			});
 		});
 
 		it('removes the expected key from the database', async () => {
-			await request.then();
 			const keys = await dashboard.database.knex.select('*').from('keys').where({
 				id: 'mock-read-key-2'
 			});
@@ -345,123 +339,115 @@ describe('DELETE /api/v1/me/keys/:keyId', () => {
 		});
 
 		it('responds with a 204 status', () => {
-			return request.expect(204);
+			assert.strictEqual(response.statusCode, 204);
 		});
 
-		it('responds with nothing', async () => {
-			const response = await request.then();
+		it('responds with nothing', () => {
 			assert.isUndefined(response.headers['content-type']);
-			assert.strictEqual(response.text, '');
+			assert.strictEqual(response.body, '');
 		});
 
 	});
 
 	describe('when :keyId is the ID of the key being used to authenticate', () => {
-		let request;
 
-		beforeEach(async () => {
+		before(async () => {
 			await database.seed(dashboard, 'basic');
-			request = agent
-				.delete('/api/v1/users/mock-admin-id/keys/mock-read-key')
-				.set('X-Api-Key', 'mock-read-key')
-				.set('X-Api-Secret', 'mock-read-secret');
+			response = await request.delete('/api/v1/users/mock-admin-id/keys/mock-read-key', {
+				headers: {
+					'X-Api-Key': 'mock-read-key',
+					'X-Api-Secret': 'mock-read-secret'
+				}
+			});
 		});
 
 		it('responds with a 403 status', () => {
-			return request.expect(403);
+			assert.strictEqual(response.statusCode, 403);
 		});
 
-		describe('JSON response', () => {
-			it('contains error details', async () => {
-				const json = (await request.then()).body;
-				assert.isObject(json);
-				assert.isString(json.message);
-				assert.strictEqual(json.status, 403);
-			});
+		it('responds with error details', () => {
+			assert.isObject(response.body);
+			assert.isString(response.body.message);
+			assert.strictEqual(response.body.status, 403);
 		});
 
 	});
 
 	describe('when :keyId is not a valid key ID', () => {
 
-		beforeEach(async () => {
+		before(async () => {
 			await database.seed(dashboard, 'basic');
-			request = agent
-				.delete('/api/v1/me/keys/not-an-id')
-				.set('X-Api-Key', 'mock-read-key')
-				.set('X-Api-Secret', 'mock-read-secret');
+			response = await request.delete('/api/v1/me/keys/not-an-id', {
+				headers: {
+					'X-Api-Key': 'mock-read-key',
+					'X-Api-Secret': 'mock-read-secret'
+				}
+			});
 		});
 
 		it('responds with a 404 status', () => {
-			return request.expect(404);
+			assert.strictEqual(response.statusCode, 404);
 		});
 
 		it('responds with JSON', () => {
-			return request.expect('Content-Type', /application\/json/);
+			assert.include(response.headers['content-type'], 'application/json');
 		});
 
-		describe('JSON response', () => {
-			it('contains error details', async () => {
-				const json = (await request.then()).body;
-				assert.isObject(json);
-				assert.isString(json.message);
-				assert.strictEqual(json.status, 404);
-			});
+		it('responds with error details', () => {
+			assert.isObject(response.body);
+			assert.isString(response.body.message);
+			assert.strictEqual(response.body.status, 404);
 		});
 
 	});
 
 	describe('when the key does not belong to the currently authenticated user', () => {
 
-		beforeEach(async () => {
+		before(async () => {
 			await database.seed(dashboard, 'basic');
-			request = agent
-				.delete('/api/v1/me/keys/mock-write-key')
-				.set('X-Api-Key', 'mock-read-key')
-				.set('X-Api-Secret', 'mock-read-secret');
+			response = await request.delete('/api/v1/me/keys/mock-write-key', {
+				headers: {
+					'X-Api-Key': 'mock-read-key',
+					'X-Api-Secret': 'mock-read-secret'
+				}
+			});
 		});
 
 		it('responds with a 404 status', () => {
-			return request.expect(404);
+			assert.strictEqual(response.statusCode, 404);
 		});
 
 		it('responds with JSON', () => {
-			return request.expect('Content-Type', /application\/json/);
+			assert.include(response.headers['content-type'], 'application/json');
 		});
 
-		describe('JSON response', () => {
-			it('contains error details', async () => {
-				const json = (await request.then()).body;
-				assert.isObject(json);
-				assert.isString(json.message);
-				assert.strictEqual(json.status, 404);
-			});
+		it('responds with error details', () => {
+			assert.isObject(response.body);
+			assert.isString(response.body.message);
+			assert.strictEqual(response.body.status, 404);
 		});
 
 	});
 
 	describe('when no API credentials are provided', () => {
 
-		beforeEach(async () => {
+		before(async () => {
 			await database.seed(dashboard, 'basic');
-			request = agent.delete('/api/v1/me/keys/mock-read-key');
+			response = await request.delete('/api/v1/me/keys/mock-read-key');
 		});
 
 		it('responds with a 401 status', () => {
-			return request.expect(401);
+			assert.strictEqual(response.statusCode, 401);
 		});
 
 		it('responds with JSON', () => {
-			return request.expect('Content-Type', /application\/json/);
+			assert.include(response.headers['content-type'], 'application/json');
 		});
 
-		describe('JSON response', () => {
-			it('contains error details', async () => {
-				const json = (await request.then()).body;
-				assert.isObject(json);
-				assert.isString(json.message);
-				assert.strictEqual(json.status, 401);
-			});
+		it('responds with error details', () => {
+			assert.isObject(response.body);
+			assert.isString(response.body.message);
+			assert.strictEqual(response.body.status, 401);
 		});
 
 	});

--- a/test/integration/routes/api-v1/me-keys.test.js
+++ b/test/integration/routes/api-v1/me-keys.test.js
@@ -1,68 +1,66 @@
 'use strict';
 
+const assert = require('proclaim');
 const bcrypt = require('bcrypt');
 const database = require('../../helpers/database');
-const assert = require('proclaim');
+let response;
 
 describe('GET /api/v1/me/keys', () => {
-	let request;
+
+	before(async () => {
+		await database.seed(dashboard, 'basic');
+	});
 
 	describe('when everything is valid', () => {
 
-		beforeEach(async () => {
-			await database.seed(dashboard, 'basic');
-			request = agent
-				.get('/api/v1/me/keys')
-				.set('X-Api-Key', 'mock-read-key')
-				.set('X-Api-Secret', 'mock-read-secret');
+		before(async () => {
+			response = await request.get('/api/v1/me/keys', {
+				headers: {
+					'X-Api-Key': 'mock-read-key',
+					'X-Api-Secret': 'mock-read-secret'
+				}
+			});
 		});
 
 		it('responds with a 200 status', () => {
-			return request.expect(200);
+			assert.strictEqual(response.statusCode, 200);
 		});
 
 		it('responds with JSON', () => {
-			return request.expect('Content-Type', /application\/json/);
+			assert.include(response.headers['content-type'], 'application/json');
 		});
 
-		describe('JSON response', () => {
-			it('is an array containing each key for the currently authenticated user in the database', async () => {
-				const json = (await request.then()).body;
-				assert.isArray(json);
-				assert.lengthEquals(json, 2);
-				assert.isObject(json[0]);
-				assert.strictEqual(json[0].id, 'mock-read-key');
-				assert.strictEqual(json[0].user, 'mock-read-id');
-				assert.isObject(json[1]);
-				assert.strictEqual(json[1].id, 'mock-read-key-2');
-				assert.strictEqual(json[1].user, 'mock-read-id');
-			});
+		it('responds with each key for the currently authenticated user', () => {
+			assert.isArray(response.body);
+			assert.lengthEquals(response.body, 2);
+			assert.isObject(response.body[0]);
+			assert.strictEqual(response.body[0].id, 'mock-read-key');
+			assert.strictEqual(response.body[0].user, 'mock-read-id');
+			assert.isObject(response.body[1]);
+			assert.strictEqual(response.body[1].id, 'mock-read-key-2');
+			assert.strictEqual(response.body[1].user, 'mock-read-id');
 		});
 
 	});
 
 	describe('when no API credentials are provided', () => {
 
-		beforeEach(async () => {
-			await database.seed(dashboard, 'basic');
-			request = agent.get('/api/v1/me/keys');
+		before(async () => {
+			response = await request.get('/api/v1/me/keys');
 		});
 
 		it('responds with a 401 status', () => {
-			return request.expect(401);
+			assert.strictEqual(response.statusCode, 401);
 		});
 
 		it('responds with JSON', () => {
-			return request.expect('Content-Type', /application\/json/);
+			assert.include(response.headers['content-type'], 'application/json');
 		});
 
-		describe('JSON response', () => {
-			it('contains error details', async () => {
-				const json = (await request.then()).body;
-				assert.isObject(json);
-				assert.isString(json.message);
-				assert.strictEqual(json.status, 401);
-			});
+		it('responds with error details', () => {
+			assert.isObject(response.body);
+			assert.isString(response.body.message);
+			assert.strictEqual(response.body.status, 401);
 		});
 
 	});
@@ -70,31 +68,31 @@ describe('GET /api/v1/me/keys', () => {
 });
 
 describe('POST /api/v1/me/keys', () => {
-	let request;
 
 	describe('when everything is valid', () => {
 
-		beforeEach(async () => {
+		before(async () => {
 			await database.seed(dashboard, 'basic');
-			request = agent
-				.post('/api/v1/me/keys')
-				.set('X-Api-Key', 'mock-read-key')
-				.set('X-Api-Secret', 'mock-read-secret')
-				.send({
+			response = await request.post('/api/v1/me/keys', {
+				headers: {
+					'Content-Type': 'application/json',
+					'X-Api-Key': 'mock-read-key',
+					'X-Api-Secret': 'mock-read-secret'
+				},
+				body: JSON.stringify({
 					id: 'extra-property-id',
 					user_id: 'mock-admin-id',
 					secret: 'extra-property-secret',
 					description: 'mock-description'
-				});
+				})
+			});
 		});
 
 		it('creates a new key in the database', async () => {
-			await request.then();
 			const keys = await dashboard.database.knex.select('*').from('keys').where({
 				description: 'mock-description'
 			});
 			const key = keys[0];
-
 			assert.lengthEquals(keys, 1, 'One key is present');
 			assert.isString(key.id, 'Key has an ID');
 			assert.notStrictEqual(key.id, 'extra-property-id', 'Key ID cannot be set in request');
@@ -105,87 +103,85 @@ describe('POST /api/v1/me/keys', () => {
 		});
 
 		it('responds with a 201 status', () => {
-			return request.expect(201);
+			assert.strictEqual(response.statusCode, 201);
 		});
 
 		it('responds with JSON', () => {
-			return request.expect('Content-Type', /application\/json/);
+			assert.include(response.headers['content-type'], 'application/json');
 		});
 
-		describe('JSON response', () => {
-			it('contains the new key and secret', async () => {
-				const json = (await request.then()).body;
-				const keys = await dashboard.database.knex.select('*').from('keys').where({
-					description: 'mock-description'
-				});
-
-				assert.isObject(json);
-				assert.strictEqual(json.key, keys[0].id);
-				assert.notStrictEqual(json.secret, keys[0].secret, 'Secret is hashed');
-				assert.isTrue(await bcrypt.compare(json.secret, keys[0].secret), 'Secret is hashed');
+		it('responds with the new key and secret', async () => {
+			const keys = await dashboard.database.knex.select('*').from('keys').where({
+				description: 'mock-description'
 			});
+			assert.isObject(response.body);
+			assert.strictEqual(response.body.key, keys[0].id);
+			assert.notStrictEqual(response.body.secret, keys[0].secret, 'Secret is hashed');
+			assert.isTrue(await bcrypt.compare(response.body.secret, keys[0].secret), 'Secret is hashed');
 		});
 
 	});
 
 	describe('when the request does not include a description property', () => {
 
-		beforeEach(async () => {
+		before(async () => {
 			await database.seed(dashboard, 'basic');
-			request = agent
-				.post('/api/v1/me/keys')
-				.set('X-Api-Key', 'mock-read-key')
-				.set('X-Api-Secret', 'mock-read-secret')
-				.send({});
+			response = await request.post('/api/v1/me/keys', {
+				headers: {
+					'Content-Type': 'application/json',
+					'X-Api-Key': 'mock-read-key',
+					'X-Api-Secret': 'mock-read-secret'
+				},
+				body: JSON.stringify({})
+			});
 		});
 
 		it('responds with a 400 status', () => {
-			return request.expect(400);
+			assert.strictEqual(response.statusCode, 400);
 		});
 
 		it('responds with JSON', () => {
-			return request.expect('Content-Type', /application\/json/);
+			assert.include(response.headers['content-type'], 'application/json');
 		});
 
-		describe('JSON response', () => {
-			it('contains error details', async () => {
-				const json = (await request.then()).body;
-				assert.isObject(json);
-				assert.isString(json.message, 'Validation failed');
-				assert.isArray(json.validation);
-				assert.deepEqual(json.validation, [
-					'"description" is required'
-				]);
-				assert.strictEqual(json.status, 400);
-			});
+		it('responds with error details', () => {
+			assert.isObject(response.body);
+			assert.isString(response.body.message);
+			assert.isArray(response.body.validation);
+			assert.deepEqual(response.body.validation, [
+				'"description" is required'
+			]);
+			assert.strictEqual(response.body.status, 400);
 		});
 
 	});
 
 	describe('when no API credentials are provided', () => {
 
-		beforeEach(async () => {
+		before(async () => {
 			await database.seed(dashboard, 'basic');
-			request = agent
-				.post('/api/v1/me/keys')
-				.send({});
+			response = await request.post('/api/v1/me/keys', {
+				headers: {
+					'Content-Type': 'application/json'
+				},
+				body: JSON.stringify({
+					description: 'mock-description'
+				})
+			});
 		});
 
 		it('responds with a 401 status', () => {
-			return request.expect(401);
+			assert.strictEqual(response.statusCode, 401);
 		});
 
 		it('responds with JSON', () => {
-			return request.expect('Content-Type', /application\/json/);
+			assert.include(response.headers['content-type'], 'application/json');
 		});
 
-		describe('JSON response', () => {
-			it('contains error details', async () => {
-				const json = (await request.then()).body;
-				assert.isObject(json);
-				assert.isString(json.message);
-				assert.strictEqual(json.status, 401);
-			});
+		it('responds with error details', () => {
+			assert.isObject(response.body);
+			assert.isString(response.body.message);
+			assert.strictEqual(response.body.status, 401);
 		});
 
 	});

--- a/test/integration/routes/api-v1/users-(id)-keys-(id).test.js
+++ b/test/integration/routes/api-v1/users-(id)-keys-(id).test.js
@@ -1,178 +1,168 @@
 'use strict';
 
-const database = require('../../helpers/database');
 const assert = require('proclaim');
+const database = require('../../helpers/database');
+let response;
 
 describe('GET /api/v1/users/:userId/keys/:keyId', () => {
-	let request;
+
+	before(async () => {
+		await database.seed(dashboard, 'basic');
+	});
 
 	describe('when everything is valid', () => {
 
-		beforeEach(async () => {
-			await database.seed(dashboard, 'basic');
-			request = agent
-				.get('/api/v1/users/mock-read-id/keys/mock-read-key')
-				.set('X-Api-Key', 'mock-admin-key')
-				.set('X-Api-Secret', 'mock-admin-secret');
+		before(async () => {
+			response = await request.get('/api/v1/users/mock-read-id/keys/mock-read-key', {
+				headers: {
+					'X-Api-Key': 'mock-admin-key',
+					'X-Api-Secret': 'mock-admin-secret'
+				}
+			});
 		});
 
 		it('responds with a 200 status', () => {
-			return request.expect(200);
+			assert.strictEqual(response.statusCode, 200);
 		});
 
 		it('responds with JSON', () => {
-			return request.expect('Content-Type', /application\/json/);
+			assert.include(response.headers['content-type'], 'application/json');
 		});
 
-		describe('JSON response', () => {
-			it('contains the key details', async () => {
-				const json = (await request.then()).body;
-				assert.isObject(json);
-				assert.strictEqual(json.id, 'mock-read-key');
-				assert.strictEqual(json.user, 'mock-read-id');
-			});
+		it('responds with the key details', () => {
+			assert.isObject(response.body);
+			assert.strictEqual(response.body.id, 'mock-read-key');
+			assert.strictEqual(response.body.user, 'mock-read-id');
 		});
 
 	});
 
 	describe('when :userId is not a valid user ID', () => {
 
-		beforeEach(async () => {
-			await database.seed(dashboard, 'basic');
-			request = agent
-				.get('/api/v1/users/not-an-id/keys/mock-read-key')
-				.set('X-Api-Key', 'mock-admin-key')
-				.set('X-Api-Secret', 'mock-admin-secret');
+		before(async () => {
+			response = await request.get('/api/v1/users/not-an-id/keys/mock-read-key', {
+				headers: {
+					'X-Api-Key': 'mock-admin-key',
+					'X-Api-Secret': 'mock-admin-secret'
+				}
+			});
 		});
 
 		it('responds with a 404 status', () => {
-			return request.expect(404);
+			assert.strictEqual(response.statusCode, 404);
 		});
 
 		it('responds with JSON', () => {
-			return request.expect('Content-Type', /application\/json/);
+			assert.include(response.headers['content-type'], 'application/json');
 		});
 
-		describe('JSON response', () => {
-			it('contains error details', async () => {
-				const json = (await request.then()).body;
-				assert.isObject(json);
-				assert.isString(json.message);
-				assert.strictEqual(json.status, 404);
-			});
+		it('responds with error details', () => {
+			assert.isObject(response.body);
+			assert.isString(response.body.message);
+			assert.strictEqual(response.body.status, 404);
 		});
 
 	});
 
 	describe('when :keyId is not a valid key ID', () => {
 
-		beforeEach(async () => {
-			await database.seed(dashboard, 'basic');
-			request = agent
-				.get('/api/v1/users/mock-read-id/keys/not-an-id')
-				.set('X-Api-Key', 'mock-admin-key')
-				.set('X-Api-Secret', 'mock-admin-secret');
+		before(async () => {
+			response = await request.get('/api/v1/users/mock-read-id/keys/not-an-id', {
+				headers: {
+					'X-Api-Key': 'mock-admin-key',
+					'X-Api-Secret': 'mock-admin-secret'
+				}
+			});
 		});
 
 		it('responds with a 404 status', () => {
-			return request.expect(404);
+			assert.strictEqual(response.statusCode, 404);
 		});
 
 		it('responds with JSON', () => {
-			return request.expect('Content-Type', /application\/json/);
+			assert.include(response.headers['content-type'], 'application/json');
 		});
 
-		describe('JSON response', () => {
-			it('contains error details', async () => {
-				const json = (await request.then()).body;
-				assert.isObject(json);
-				assert.isString(json.message);
-				assert.strictEqual(json.status, 404);
-			});
+		it('responds with error details', () => {
+			assert.isObject(response.body);
+			assert.isString(response.body.message);
+			assert.strictEqual(response.body.status, 404);
 		});
 
 	});
 
 	describe('when :userId and :keyId are mismatched', () => {
 
-		beforeEach(async () => {
-			await database.seed(dashboard, 'basic');
-			request = agent
-				.get('/api/v1/users/mock-read-id/keys/mock-write-key')
-				.set('X-Api-Key', 'mock-admin-key')
-				.set('X-Api-Secret', 'mock-admin-secret');
+		before(async () => {
+			response = await request.get('/api/v1/users/mock-read-id/keys/mock-write-key', {
+				headers: {
+					'X-Api-Key': 'mock-admin-key',
+					'X-Api-Secret': 'mock-admin-secret'
+				}
+			});
 		});
 
 		it('responds with a 404 status', () => {
-			return request.expect(404);
+			assert.strictEqual(response.statusCode, 404);
 		});
 
 		it('responds with JSON', () => {
-			return request.expect('Content-Type', /application\/json/);
+			assert.include(response.headers['content-type'], 'application/json');
 		});
 
-		describe('JSON response', () => {
-			it('contains error details', async () => {
-				const json = (await request.then()).body;
-				assert.isObject(json);
-				assert.isString(json.message);
-				assert.strictEqual(json.status, 404);
-			});
+		it('responds with error details', () => {
+			assert.isObject(response.body);
+			assert.isString(response.body.message);
+			assert.strictEqual(response.body.status, 404);
 		});
 
 	});
 
 	describe('when no API credentials are provided', () => {
 
-		beforeEach(async () => {
-			await database.seed(dashboard, 'basic');
-			request = agent.get('/api/v1/users/mock-read-id/keys/mock-read-key');
+		before(async () => {
+			response = await request.get('/api/v1/users/mock-read-id/keys/mock-read-key');
 		});
 
 		it('responds with a 403 status', () => {
-			return request.expect(403);
+			assert.strictEqual(response.statusCode, 403);
 		});
 
 		it('responds with JSON', () => {
-			return request.expect('Content-Type', /application\/json/);
+			assert.include(response.headers['content-type'], 'application/json');
 		});
 
-		describe('JSON response', () => {
-			it('contains error details', async () => {
-				const json = (await request.then()).body;
-				assert.isObject(json);
-				assert.isString(json.message);
-				assert.strictEqual(json.status, 403);
-			});
+		it('responds with error details', () => {
+			assert.isObject(response.body);
+			assert.isString(response.body.message);
+			assert.strictEqual(response.body.status, 403);
 		});
 
 	});
 
 	describe('when the provided API key does not have the required permissions', () => {
 
-		beforeEach(async () => {
-			await database.seed(dashboard, 'basic');
-			request = agent
-				.get('/api/v1/users/mock-read-id/keys/mock-read-key')
-				.set('X-Api-Key', 'mock-delete-key')
-				.set('X-Api-Secret', 'mock-delete-secret');
+		before(async () => {
+			response = await request.get('/api/v1/users/mock-read-id/keys/mock-read-key', {
+				headers: {
+					'X-Api-Key': 'mock-delete-key',
+					'X-Api-Secret': 'mock-delete-secret'
+				}
+			});
 		});
 
 		it('responds with a 403 status', () => {
-			return request.expect(403);
+			assert.strictEqual(response.statusCode, 403);
 		});
 
 		it('responds with JSON', () => {
-			return request.expect('Content-Type', /application\/json/);
+			assert.include(response.headers['content-type'], 'application/json');
 		});
 
-		describe('JSON response', () => {
-			it('contains error details', async () => {
-				const json = (await request.then()).body;
-				assert.isObject(json);
-				assert.isString(json.message);
-				assert.strictEqual(json.status, 403);
-			});
+		it('responds with error details', () => {
+			assert.isObject(response.body);
+			assert.isString(response.body.message);
+			assert.strictEqual(response.body.status, 403);
 		});
 
 	});
@@ -180,26 +170,27 @@ describe('GET /api/v1/users/:userId/keys/:keyId', () => {
 });
 
 describe('PATCH /api/v1/users/:userId/keys/:keyId', () => {
-	let request;
 
 	describe('when everything is valid', () => {
 
-		beforeEach(async () => {
+		before(async () => {
 			await database.seed(dashboard, 'basic');
-			request = agent
-				.patch('/api/v1/users/mock-read-id/keys/mock-read-key')
-				.set('X-Api-Key', 'mock-admin-key')
-				.set('X-Api-Secret', 'mock-admin-secret')
-				.send({
+			response = await request.patch('/api/v1/users/mock-read-id/keys/mock-read-key', {
+				headers: {
+					'Content-Type': 'application/json',
+					'X-Api-Key': 'mock-admin-key',
+					'X-Api-Secret': 'mock-admin-secret'
+				},
+				body: JSON.stringify({
 					id: 'extra-property-id',
 					secret: 'extra-property-secret',
 					user_id: 'extra-property-user-id',
 					description: 'new-description'
-				});
+				})
+			});
 		});
 
 		it('updates the key in the database', async () => {
-			await request.then();
 			const keys = await dashboard.database.knex.select('*').from('keys').where({
 				description: 'new-description'
 			});
@@ -213,264 +204,264 @@ describe('PATCH /api/v1/users/:userId/keys/:keyId', () => {
 		});
 
 		it('responds with a 200 status', () => {
-			return request.expect(200);
+			assert.strictEqual(response.statusCode, 200);
 		});
 
 		it('responds with JSON', () => {
-			return request.expect('Content-Type', /application\/json/);
+			assert.include(response.headers['content-type'], 'application/json');
 		});
 
-		describe('JSON response', () => {
-			it('contains the updated key details', async () => {
-				const json = (await request.then()).body;
-				assert.isObject(json);
-				assert.strictEqual(json.id, 'mock-read-key');
-				assert.strictEqual(json.user, 'mock-read-id');
-				assert.strictEqual(json.description, 'new-description');
-			});
+		it('responds with the updated key details', () => {
+			assert.isObject(response.body);
+			assert.strictEqual(response.body.id, 'mock-read-key');
+			assert.strictEqual(response.body.user, 'mock-read-id');
+			assert.strictEqual(response.body.description, 'new-description');
 		});
 
 	});
 
 	describe('when the request has no data set', () => {
 
-		beforeEach(async () => {
+		before(async () => {
 			await database.seed(dashboard, 'basic');
-			request = agent
-				.patch('/api/v1/users/mock-read-id/keys/mock-read-key')
-				.set('X-Api-Key', 'mock-admin-key')
-				.set('X-Api-Secret', 'mock-admin-secret')
-				.send({});
+			response = await request.patch('/api/v1/users/mock-read-id/keys/mock-read-key', {
+				headers: {
+					'Content-Type': 'application/json',
+					'X-Api-Key': 'mock-admin-key',
+					'X-Api-Secret': 'mock-admin-secret'
+				},
+				body: JSON.stringify({})
+			});
 		});
 
 		it('responds with a 200 status', () => {
-			return request.expect(200);
+			assert.strictEqual(response.statusCode, 200);
 		});
 
 	});
 
 	describe('when the request includes an invalid description property', () => {
 
-		beforeEach(async () => {
+		before(async () => {
 			await database.seed(dashboard, 'basic');
-			request = agent
-				.patch('/api/v1/users/mock-read-id/keys/mock-read-key')
-				.set('X-Api-Key', 'mock-admin-key')
-				.set('X-Api-Secret', 'mock-admin-secret')
-				.send({
+			response = await request.patch('/api/v1/users/mock-read-id/keys/mock-read-key', {
+				headers: {
+					'Content-Type': 'application/json',
+					'X-Api-Key': 'mock-admin-key',
+					'X-Api-Secret': 'mock-admin-secret'
+				},
+				body: JSON.stringify({
 					description: []
-				});
+				})
+			});
 		});
 
 		it('responds with a 400 status', () => {
-			return request.expect(400);
+			assert.strictEqual(response.statusCode, 400);
 		});
 
 		it('responds with JSON', () => {
-			return request.expect('Content-Type', /application\/json/);
+			assert.include(response.headers['content-type'], 'application/json');
 		});
 
-		describe('JSON response', () => {
-			it('contains error details', async () => {
-				const json = (await request.then()).body;
-				assert.isObject(json);
-				assert.isString(json.message, 'Validation failed');
-				assert.isArray(json.validation);
-				assert.deepEqual(json.validation, [
-					'"description" must be a string'
-				]);
-				assert.strictEqual(json.status, 400);
-			});
+		it('responds with error details', () => {
+			assert.isObject(response.body);
+			assert.isString(response.body.message, 'Validation failed');
+			assert.isArray(response.body.validation);
+			assert.deepEqual(response.body.validation, [
+				'"description" must be a string'
+			]);
+			assert.strictEqual(response.body.status, 400);
 		});
 
 	});
 
 	describe('when :userId is not a valid user ID', () => {
 
-		beforeEach(async () => {
+		before(async () => {
 			await database.seed(dashboard, 'basic');
-			request = agent
-				.patch('/api/v1/users/not-an-id/keys/mock-read-key')
-				.set('X-Api-Key', 'mock-admin-key')
-				.set('X-Api-Secret', 'mock-admin-secret')
-				.send({
+			response = await request.patch('/api/v1/users/not-an-id/keys/mock-read-key', {
+				headers: {
+					'Content-Type': 'application/json',
+					'X-Api-Key': 'mock-admin-key',
+					'X-Api-Secret': 'mock-admin-secret'
+				},
+				body: JSON.stringify({
 					description: 'new-description'
-				});
+				})
+			});
 		});
 
 		it('responds with a 404 status', () => {
-			return request.expect(404);
+			assert.strictEqual(response.statusCode, 404);
 		});
 
 		it('responds with JSON', () => {
-			return request.expect('Content-Type', /application\/json/);
+			assert.include(response.headers['content-type'], 'application/json');
 		});
 
-		describe('JSON response', () => {
-			it('contains error details', async () => {
-				const json = (await request.then()).body;
-				assert.isObject(json);
-				assert.isString(json.message);
-				assert.strictEqual(json.status, 404);
-			});
+		it('responds with error details', () => {
+			assert.isObject(response.body);
+			assert.isString(response.body.message);
+			assert.strictEqual(response.body.status, 404);
 		});
 
 	});
 
 	describe('when :keyId is not a valid key ID', () => {
 
-		beforeEach(async () => {
+		before(async () => {
 			await database.seed(dashboard, 'basic');
-			request = agent
-				.patch('/api/v1/users/mock-read-id/keys/not-an-id')
-				.set('X-Api-Key', 'mock-admin-key')
-				.set('X-Api-Secret', 'mock-admin-secret')
-				.send({
+			response = await request.patch('/api/v1/users/mock-read-id/keys/not-an-id', {
+				headers: {
+					'Content-Type': 'application/json',
+					'X-Api-Key': 'mock-admin-key',
+					'X-Api-Secret': 'mock-admin-secret'
+				},
+				body: JSON.stringify({
 					description: 'new-description'
-				});
+				})
+			});
 		});
 
 		it('responds with a 404 status', () => {
-			return request.expect(404);
+			assert.strictEqual(response.statusCode, 404);
 		});
 
 		it('responds with JSON', () => {
-			return request.expect('Content-Type', /application\/json/);
+			assert.include(response.headers['content-type'], 'application/json');
 		});
 
-		describe('JSON response', () => {
-			it('contains error details', async () => {
-				const json = (await request.then()).body;
-				assert.isObject(json);
-				assert.isString(json.message);
-				assert.strictEqual(json.status, 404);
-			});
+		it('responds with error details', () => {
+			assert.isObject(response.body);
+			assert.isString(response.body.message);
+			assert.strictEqual(response.body.status, 404);
 		});
 
 	});
 
 	describe('when :userId and :keyId are mismatched', () => {
 
-		beforeEach(async () => {
+		before(async () => {
 			await database.seed(dashboard, 'basic');
-			request = agent
-				.patch('/api/v1/users/mock-read-id/keys/mock-write-key')
-				.set('X-Api-Key', 'mock-admin-key')
-				.set('X-Api-Secret', 'mock-admin-secret')
-				.send({
+			response = await request.patch('/api/v1/users/mock-read-id/keys/mock-write-key', {
+				headers: {
+					'Content-Type': 'application/json',
+					'X-Api-Key': 'mock-admin-key',
+					'X-Api-Secret': 'mock-admin-secret'
+				},
+				body: JSON.stringify({
 					description: 'new-description'
-				});
+				})
+			});
 		});
 
 		it('responds with a 404 status', () => {
-			return request.expect(404);
+			assert.strictEqual(response.statusCode, 404);
 		});
 
 		it('responds with JSON', () => {
-			return request.expect('Content-Type', /application\/json/);
+			assert.include(response.headers['content-type'], 'application/json');
 		});
 
-		describe('JSON response', () => {
-			it('contains error details', async () => {
-				const json = (await request.then()).body;
-				assert.isObject(json);
-				assert.isString(json.message);
-				assert.strictEqual(json.status, 404);
-			});
+		it('responds with error details', () => {
+			assert.isObject(response.body);
+			assert.isString(response.body.message);
+			assert.strictEqual(response.body.status, 404);
 		});
 
 	});
 
 	describe('when :userId is the ID of an owner', () => {
 
-		beforeEach(async () => {
+		before(async () => {
 			await database.seed(dashboard, 'basic');
-			request = agent
-				.patch('/api/v1/users/mock-owner-id/keys/mock-owner-key')
-				.set('X-Api-Key', 'mock-admin-key')
-				.set('X-Api-Secret', 'mock-admin-secret')
-				.send({
+			response = await request.patch('/api/v1/users/mock-owner-id/keys/mock-owner-key', {
+				headers: {
+					'Content-Type': 'application/json',
+					'X-Api-Key': 'mock-admin-key',
+					'X-Api-Secret': 'mock-admin-secret'
+				},
+				body: JSON.stringify({
 					description: 'new-description'
-				});
+				})
+			});
 		});
 
 		it('responds with a 403 status', () => {
-			return request.expect(403);
+			assert.strictEqual(response.statusCode, 403);
 		});
 
 		it('responds with JSON', () => {
-			return request.expect('Content-Type', /application\/json/);
+			assert.include(response.headers['content-type'], 'application/json');
 		});
 
-		describe('JSON response', () => {
-			it('contains error details', async () => {
-				const json = (await request.then()).body;
-				assert.isObject(json);
-				assert.isString(json.message);
-				assert.strictEqual(json.status, 403);
-			});
+		it('responds with error details', () => {
+			assert.isObject(response.body);
+			assert.isString(response.body.message);
+			assert.strictEqual(response.body.status, 403);
 		});
 
 	});
 
 	describe('when no API credentials are provided', () => {
 
-		beforeEach(async () => {
+		before(async () => {
 			await database.seed(dashboard, 'basic');
-			request = agent
-				.patch('/api/v1/users/mock-read-id/keys/mock-read-key')
-				.send({
+			response = await request.patch('/api/v1/users/mock-read-id/keys/mock-read-key', {
+				headers: {
+					'Content-Type': 'application/json'
+				},
+				body: JSON.stringify({
 					description: 'new-description'
-				});
+				})
+			});
 		});
 
 		it('responds with a 403 status', () => {
-			return request.expect(403);
+			assert.strictEqual(response.statusCode, 403);
 		});
 
 		it('responds with JSON', () => {
-			return request.expect('Content-Type', /application\/json/);
+			assert.include(response.headers['content-type'], 'application/json');
 		});
 
-		describe('JSON response', () => {
-			it('contains error details', async () => {
-				const json = (await request.then()).body;
-				assert.isObject(json);
-				assert.isString(json.message);
-				assert.strictEqual(json.status, 403);
-			});
+		it('responds with error details', () => {
+			assert.isObject(response.body);
+			assert.isString(response.body.message);
+			assert.strictEqual(response.body.status, 403);
 		});
 
 	});
 
 	describe('when the provided API key does not have the required permissions', () => {
 
-		beforeEach(async () => {
+		before(async () => {
 			await database.seed(dashboard, 'basic');
-			request = agent
-				.patch('/api/v1/users/mock-read-id/keys/mock-read-key')
-				.set('X-Api-Key', 'mock-delete-key')
-				.set('X-Api-Secret', 'mock-delete-secret')
-				.send({
+			response = await request.patch('/api/v1/users/mock-read-id/keys/mock-read-key', {
+				headers: {
+					'Content-Type': 'application/json',
+					'X-Api-Key': 'mock-delete-key',
+					'X-Api-Secret': 'mock-delete-secret'
+				},
+				body: JSON.stringify({
 					description: 'new-description'
-				});
+				})
+			});
 		});
 
 		it('responds with a 403 status', () => {
-			return request.expect(403);
+			assert.strictEqual(response.statusCode, 403);
 		});
 
 		it('responds with JSON', () => {
-			return request.expect('Content-Type', /application\/json/);
+			assert.include(response.headers['content-type'], 'application/json');
 		});
 
-		describe('JSON response', () => {
-			it('contains error details', async () => {
-				const json = (await request.then()).body;
-				assert.isObject(json);
-				assert.isString(json.message);
-				assert.strictEqual(json.status, 403);
-			});
+		it('responds with error details', () => {
+			assert.isObject(response.body);
+			assert.isString(response.body.message);
+			assert.strictEqual(response.body.status, 403);
 		});
 
 	});
@@ -478,20 +469,20 @@ describe('PATCH /api/v1/users/:userId/keys/:keyId', () => {
 });
 
 describe('DELETE /api/v1/users/:userId/keys/:keyId', () => {
-	let request;
 
 	describe('when everything is valid', () => {
 
-		beforeEach(async () => {
+		before(async () => {
 			await database.seed(dashboard, 'basic');
-			request = agent
-				.delete('/api/v1/users/mock-read-id/keys/mock-read-key')
-				.set('X-Api-Key', 'mock-admin-key')
-				.set('X-Api-Secret', 'mock-admin-secret');
+			response = await request.delete('/api/v1/users/mock-read-id/keys/mock-read-key', {
+				headers: {
+					'X-Api-Key': 'mock-admin-key',
+					'X-Api-Secret': 'mock-admin-secret'
+				}
+			});
 		});
 
 		it('removes the expected key from the database', async () => {
-			await request.then();
 			const keys = await dashboard.database.knex.select('*').from('keys').where({
 				id: 'mock-read-key'
 			});
@@ -499,210 +490,199 @@ describe('DELETE /api/v1/users/:userId/keys/:keyId', () => {
 		});
 
 		it('responds with a 204 status', () => {
-			return request.expect(204);
+			assert.strictEqual(response.statusCode, 204);
 		});
 
-		it('responds with nothing', async () => {
-			const response = await request.then();
+		it('responds with nothing', () => {
 			assert.isUndefined(response.headers['content-type']);
-			assert.strictEqual(response.text, '');
+			assert.strictEqual(response.body, '');
 		});
 
 	});
 
 	describe('when :keyId is the ID of the key being used to authenticate', () => {
-		let request;
 
-		beforeEach(async () => {
+		before(async () => {
 			await database.seed(dashboard, 'basic');
-			request = agent
-				.delete('/api/v1/users/mock-admin-id/keys/mock-admin-key')
-				.set('X-Api-Key', 'mock-admin-key')
-				.set('X-Api-Secret', 'mock-admin-secret');
+			response = await request.delete('/api/v1/users/mock-admin-id/keys/mock-admin-key', {
+				headers: {
+					'X-Api-Key': 'mock-admin-key',
+					'X-Api-Secret': 'mock-admin-secret'
+				}
+			});
 		});
 
 		it('responds with a 403 status', () => {
-			return request.expect(403);
+			assert.strictEqual(response.statusCode, 403);
 		});
 
-		describe('JSON response', () => {
-			it('contains error details', async () => {
-				const json = (await request.then()).body;
-				assert.isObject(json);
-				assert.isString(json.message);
-				assert.strictEqual(json.status, 403);
-			});
+		it('responds with error details', () => {
+			assert.isObject(response.body);
+			assert.isString(response.body.message);
+			assert.strictEqual(response.body.status, 403);
 		});
 
 	});
 
 	describe('when :userId is not a valid user ID', () => {
 
-		beforeEach(async () => {
+		before(async () => {
 			await database.seed(dashboard, 'basic');
-			request = agent
-				.delete('/api/v1/users/not-an-id/keys/mock-read-key')
-				.set('X-Api-Key', 'mock-admin-key')
-				.set('X-Api-Secret', 'mock-admin-secret');
+			response = await request.delete('/api/v1/users/not-an-id/keys/mock-read-key', {
+				headers: {
+					'X-Api-Key': 'mock-admin-key',
+					'X-Api-Secret': 'mock-admin-secret'
+				}
+			});
 		});
 
 		it('responds with a 404 status', () => {
-			return request.expect(404);
+			assert.strictEqual(response.statusCode, 404);
 		});
 
 		it('responds with JSON', () => {
-			return request.expect('Content-Type', /application\/json/);
+			assert.include(response.headers['content-type'], 'application/json');
 		});
 
-		describe('JSON response', () => {
-			it('contains error details', async () => {
-				const json = (await request.then()).body;
-				assert.isObject(json);
-				assert.isString(json.message);
-				assert.strictEqual(json.status, 404);
-			});
+		it('responds with error details', () => {
+			assert.isObject(response.body);
+			assert.isString(response.body.message);
+			assert.strictEqual(response.body.status, 404);
 		});
 
 	});
 
 	describe('when :keyId is not a valid key ID', () => {
 
-		beforeEach(async () => {
+		before(async () => {
 			await database.seed(dashboard, 'basic');
-			request = agent
-				.delete('/api/v1/users/mock-read-id/keys/not-an-id')
-				.set('X-Api-Key', 'mock-admin-key')
-				.set('X-Api-Secret', 'mock-admin-secret');
+			response = await request.delete('/api/v1/users/mock-read-id/keys/not-an-id', {
+				headers: {
+					'X-Api-Key': 'mock-admin-key',
+					'X-Api-Secret': 'mock-admin-secret'
+				}
+			});
 		});
 
 		it('responds with a 404 status', () => {
-			return request.expect(404);
+			assert.strictEqual(response.statusCode, 404);
 		});
 
 		it('responds with JSON', () => {
-			return request.expect('Content-Type', /application\/json/);
+			assert.include(response.headers['content-type'], 'application/json');
 		});
 
-		describe('JSON response', () => {
-			it('contains error details', async () => {
-				const json = (await request.then()).body;
-				assert.isObject(json);
-				assert.isString(json.message);
-				assert.strictEqual(json.status, 404);
-			});
+		it('responds with error details', () => {
+			assert.isObject(response.body);
+			assert.isString(response.body.message);
+			assert.strictEqual(response.body.status, 404);
 		});
 
 	});
 
 	describe('when :userId and :keyId are mismatched', () => {
 
-		beforeEach(async () => {
+		before(async () => {
 			await database.seed(dashboard, 'basic');
-			request = agent
-				.delete('/api/v1/users/mock-read-id/keys/mock-write-key')
-				.set('X-Api-Key', 'mock-admin-key')
-				.set('X-Api-Secret', 'mock-admin-secret');
+			response = await request.delete('/api/v1/users/mock-read-id/keys/mock-write-key', {
+				headers: {
+					'X-Api-Key': 'mock-admin-key',
+					'X-Api-Secret': 'mock-admin-secret'
+				}
+			});
 		});
 
 		it('responds with a 404 status', () => {
-			return request.expect(404);
+			assert.strictEqual(response.statusCode, 404);
 		});
 
 		it('responds with JSON', () => {
-			return request.expect('Content-Type', /application\/json/);
+			assert.include(response.headers['content-type'], 'application/json');
 		});
 
-		describe('JSON response', () => {
-			it('contains error details', async () => {
-				const json = (await request.then()).body;
-				assert.isObject(json);
-				assert.isString(json.message);
-				assert.strictEqual(json.status, 404);
-			});
+		it('responds with error details', () => {
+			assert.isObject(response.body);
+			assert.isString(response.body.message);
+			assert.strictEqual(response.body.status, 404);
 		});
 
 	});
 
 	describe('when :userId is the ID of an owner', () => {
 
-		beforeEach(async () => {
+		before(async () => {
 			await database.seed(dashboard, 'basic');
-			request = agent
-				.delete('/api/v1/users/mock-owner-id/keys/mock-owner-key')
-				.set('X-Api-Key', 'mock-admin-key')
-				.set('X-Api-Secret', 'mock-admin-secret');
+			response = await request.delete('/api/v1/users/mock-owner-id/keys/mock-owner-key', {
+				headers: {
+					'X-Api-Key': 'mock-admin-key',
+					'X-Api-Secret': 'mock-admin-secret'
+				}
+			});
 		});
 
 		it('responds with a 403 status', () => {
-			return request.expect(403);
+			assert.strictEqual(response.statusCode, 403);
 		});
 
 		it('responds with JSON', () => {
-			return request.expect('Content-Type', /application\/json/);
+			assert.include(response.headers['content-type'], 'application/json');
 		});
 
-		describe('JSON response', () => {
-			it('contains error details', async () => {
-				const json = (await request.then()).body;
-				assert.isObject(json);
-				assert.isString(json.message);
-				assert.strictEqual(json.status, 403);
-			});
+		it('responds with error details', () => {
+			assert.isObject(response.body);
+			assert.isString(response.body.message);
+			assert.strictEqual(response.body.status, 403);
 		});
 
 	});
 
 	describe('when no API credentials are provided', () => {
 
-		beforeEach(async () => {
+		before(async () => {
 			await database.seed(dashboard, 'basic');
-			request = agent.delete('/api/v1/users/mock-read-id/keys/mock-read-key');
+			response = await request.delete('/api/v1/users/mock-read-id/keys/mock-read-key');
 		});
 
 		it('responds with a 403 status', () => {
-			return request.expect(403);
+			assert.strictEqual(response.statusCode, 403);
 		});
 
 		it('responds with JSON', () => {
-			return request.expect('Content-Type', /application\/json/);
+			assert.include(response.headers['content-type'], 'application/json');
 		});
 
-		describe('JSON response', () => {
-			it('contains error details', async () => {
-				const json = (await request.then()).body;
-				assert.isObject(json);
-				assert.isString(json.message);
-				assert.strictEqual(json.status, 403);
-			});
+		it('responds with error details', () => {
+			assert.isObject(response.body);
+			assert.isString(response.body.message);
+			assert.strictEqual(response.body.status, 403);
 		});
 
 	});
 
 	describe('when the provided API key does not have the required permissions', () => {
 
-		beforeEach(async () => {
+		before(async () => {
 			await database.seed(dashboard, 'basic');
-			request = agent
-				.delete('/api/v1/users/mock-read-id/keys/mock-read-key')
-				.set('X-Api-Key', 'mock-write-key')
-				.set('X-Api-Secret', 'mock-write-secret');
+			response = await request.delete('/api/v1/users/mock-read-id/keys/mock-read-key', {
+				headers: {
+					'X-Api-Key': 'mock-write-key',
+					'X-Api-Secret': 'mock-write-secret'
+				}
+			});
 		});
 
 		it('responds with a 403 status', () => {
-			return request.expect(403);
+			assert.strictEqual(response.statusCode, 403);
 		});
 
 		it('responds with JSON', () => {
-			return request.expect('Content-Type', /application\/json/);
+			assert.include(response.headers['content-type'], 'application/json');
 		});
 
-		describe('JSON response', () => {
-			it('contains error details', async () => {
-				const json = (await request.then()).body;
-				assert.isObject(json);
-				assert.isString(json.message);
-				assert.strictEqual(json.status, 403);
-			});
+		it('responds with error details', () => {
+			assert.isObject(response.body);
+			assert.isString(response.body.message);
+			assert.strictEqual(response.body.status, 403);
 		});
 
 	});

--- a/test/integration/routes/front-end/404.test.js
+++ b/test/integration/routes/front-end/404.test.js
@@ -2,28 +2,33 @@
 
 const assert = require('proclaim');
 const database = require('../../helpers/database');
+let response;
 
 describe('GET /404', () => {
-	let request;
 
-	beforeEach(async () => {
+	before(async () => {
 		await database.seed(dashboard, 'basic');
-		request = agent.get('/404');
 	});
 
-	it('responds with a 404 status', () => {
-		return request.expect(404);
-	});
+	describe('when everything is valid', () => {
 
-	it('responds with HTML', () => {
-		return request.expect('Content-Type', /text\/html/);
-	});
-
-	describe('HTML response', () => {
-		it('contains a 404 error message', async () => {
-			const html = (await request.then()).text;
-			assert.match(html, /not found/i);
+		before(async () => {
+			response = await request.get('/404');
 		});
+
+		it('responds with a 404 status', () => {
+			assert.strictEqual(response.statusCode, 404);
+		});
+
+		it('responds with HTML', () => {
+			assert.include(response.headers['content-type'], 'text/html');
+		});
+
+		it('it responds with an error page', () => {
+			const body = response.body.document.querySelector('body');
+			assert.match(body.innerHTML, /not found/i);
+		});
+
 	});
 
 });

--- a/test/integration/routes/front-end/docs-api-v1.test.js
+++ b/test/integration/routes/front-end/docs-api-v1.test.js
@@ -1,21 +1,29 @@
 'use strict';
 
+const assert = require('proclaim');
 const database = require('../../helpers/database');
+let response;
 
 describe('GET /docs/api/v1', () => {
-	let request;
 
-	beforeEach(async () => {
+	before(async () => {
 		await database.seed(dashboard, 'basic');
-		request = agent.get('/docs/api/v1');
 	});
 
-	it('responds with a 200 status', () => {
-		return request.expect(200);
-	});
+	describe('when everything is valid', () => {
 
-	it('responds with HTML', () => {
-		return request.expect('Content-Type', /text\/html/);
+		before(async () => {
+			response = await request.get('/docs/api/v1');
+		});
+
+		it('responds with a 200 status', () => {
+			assert.strictEqual(response.statusCode, 200);
+		});
+
+		it('responds with HTML', () => {
+			assert.include(response.headers['content-type'], 'text/html');
+		});
+
 	});
 
 });

--- a/test/integration/routes/front-end/index.test.js
+++ b/test/integration/routes/front-end/index.test.js
@@ -2,29 +2,34 @@
 
 const assert = require('proclaim');
 const database = require('../../helpers/database');
+let response;
 
 describe('GET /', () => {
-	let request;
 
-	beforeEach(async () => {
+	before(async () => {
 		await database.seed(dashboard, 'basic');
-		request = agent.get('/');
 	});
 
-	it('responds with a 200 status', () => {
-		return request.expect(200);
-	});
+	describe('when everything is valid', () => {
 
-	it('responds with HTML', () => {
-		return request.expect('Content-Type', /text\/html/);
-	});
-
-	// Temporary until home page has more content
-	describe('HTML response', () => {
-		it('is the home page', async () => {
-			const html = (await request.then()).text;
-			assert.match(html, /hello world/i);
+		before(async () => {
+			response = await request.get('/');
 		});
+
+		it('responds with a 200 status', () => {
+			assert.strictEqual(response.statusCode, 200);
+		});
+
+		it('responds with HTML', () => {
+			assert.include(response.headers['content-type'], 'text/html');
+		});
+
+		// Temporary until home page has more content
+		it('it responds with the home page', () => {
+			const body = response.body.document.querySelector('body');
+			assert.match(body.innerHTML, /hello world/i);
+		});
+
 	});
 
 });

--- a/test/integration/routes/front-end/login.test.js
+++ b/test/integration/routes/front-end/login.test.js
@@ -2,44 +2,39 @@
 
 const assert = require('proclaim');
 const database = require('../../helpers/database');
-const {JSDOM} = require('jsdom');
+const querystring = require('querystring');
+let response;
 
 describe('GET /login', () => {
-	let request;
 
-	beforeEach(async () => {
+	before(async () => {
 		await database.seed(dashboard, 'basic');
-		request = agent.get('/login');
 	});
 
-	it('responds with a 200 status', () => {
-		return request.expect(200);
-	});
+	describe('when everything is valid', () => {
 
-	it('responds with HTML', () => {
-		return request.expect('Content-Type', /text\/html/);
-	});
-
-	describe('HTML response', () => {
-		let dom;
-		let errors;
-		let form;
-
-		beforeEach(async () => {
-			dom = new JSDOM((await request.then()).text);
-			form = dom.window.document.querySelector('[data-test=login-form]');
-			errors = form.querySelectorAll('[data-test=alert-error]');
+		before(async () => {
+			response = await request.get('/login');
 		});
 
-		it('contains no error messages', () => {
+		it('responds with a 200 status', () => {
+			assert.strictEqual(response.statusCode, 200);
+		});
+
+		it('responds with HTML', () => {
+			assert.include(response.headers['content-type'], 'text/html');
+		});
+
+		it('responds with no error messages', () => {
+			const errors = response.body.document.querySelectorAll('[data-test=login-form] [data-test=alert-error]');
 			assert.lengthEquals(errors, 0);
 		});
 
-		it('contains a login form', () => {
+		it('responds with a login form', () => {
+			const form = response.body.document.querySelector('[data-test=login-form]');
 			assert.isNotNull(form);
 			assert.strictEqual(form.getAttribute('action'), '/login');
 			assert.strictEqual(form.getAttribute('method'), 'post');
-			assert.strictEqual(form.getAttribute('enctype'), 'application/x-www-form-urlencoded');
 
 			const emailField = form.querySelector('input[name="email"]');
 			assert.strictEqual(emailField.getAttribute('type'), 'email');
@@ -58,32 +53,43 @@ describe('GET /login', () => {
 });
 
 describe('GET /login?referer=:referer', () => {
-	let request;
 
-	beforeEach(async () => {
+	before(async () => {
 		await database.seed(dashboard, 'basic');
-		request = agent.get('/login?referer=/mock-referer');
 	});
 
-	it('responds with a 200 status', () => {
-		return request.expect(200);
-	});
+	describe('when everything is valid', () => {
 
-	it('responds with HTML', () => {
-		return request.expect('Content-Type', /text\/html/);
-	});
-
-	describe('HTML response', () => {
-		let dom;
-		let form;
-
-		beforeEach(async () => {
-			dom = new JSDOM((await request.then()).text);
-			form = dom.window.document.querySelector('[data-test=login-form]');
+		before(async () => {
+			response = await request.get('/login?referer=/mock-referer');
 		});
 
-		it('contains a login form with a referer field', () => {
+		it('responds with a 200 status', () => {
+			assert.strictEqual(response.statusCode, 200);
+		});
+
+		it('responds with HTML', () => {
+			assert.include(response.headers['content-type'], 'text/html');
+		});
+
+		it('responds with no error messages', () => {
+			const errors = response.body.document.querySelectorAll('[data-test=login-form] [data-test=alert-error]');
+			assert.lengthEquals(errors, 0);
+		});
+
+		it('responds with a login form that has a referer field', () => {
+			const form = response.body.document.querySelector('[data-test=login-form]');
 			assert.isNotNull(form);
+			assert.strictEqual(form.getAttribute('action'), '/login');
+			assert.strictEqual(form.getAttribute('method'), 'post');
+
+			const emailField = form.querySelector('input[name="email"]');
+			assert.strictEqual(emailField.getAttribute('type'), 'email');
+			assert.strictEqual(emailField.getAttribute('value'), '');
+
+			const passwordField = form.querySelector('input[name="password"]');
+			assert.strictEqual(passwordField.getAttribute('type'), 'password');
+			assert.strictEqual(passwordField.getAttribute('value'), '');
 
 			const refererField = form.querySelector('input[name="referer"]');
 			assert.strictEqual(refererField.getAttribute('type'), 'hidden');
@@ -95,26 +101,23 @@ describe('GET /login?referer=:referer', () => {
 });
 
 describe('POST /login', () => {
-	let request;
-
-	beforeEach(async () => {
-		await database.seed(dashboard, 'basic');
-		request = agent
-			.post('/login')
-			.set('Content-Type', 'application/x-www-form-urlencoded');
-	});
 
 	describe('when everything is valid', () => {
 
-		beforeEach(() => {
-			request.send({
-				email: 'admin@example.com',
-				password: 'password'
+		before(async () => {
+			await database.seed(dashboard, 'basic');
+			response = await request.post('/login', {
+				headers: {
+					'Content-Type': 'application/x-www-form-urlencoded'
+				},
+				body: querystring.stringify({
+					email: 'admin@example.com',
+					password: 'password'
+				})
 			});
 		});
 
 		it('creates a login session', async () => {
-			const response = await request.then();
 			const sessions = await dashboard.database.knex.select('*').from('sessions').limit(1);
 			const session = sessions[0];
 
@@ -129,155 +132,149 @@ describe('POST /login', () => {
 		});
 
 		it('responds with a 302 status', () => {
-			return request.expect(302);
+			assert.strictEqual(response.statusCode, 302);
 		});
 
 		it('responds with a Location header pointing to the home page', () => {
-			return request.expect('Location', '/');
+			assert.strictEqual(response.headers.location, '/');
 		});
 
 		it('responds with plain text', () => {
-			return request.expect('Content-Type', /text\/plain/);
+			assert.include(response.headers['content-type'], 'text/plain');
 		});
 
 	});
 
 	describe('when a referer was sent with the form', () => {
 
-		beforeEach(() => {
-			request.send({
-				email: 'admin@example.com',
-				password: 'password',
-				referer: '/mock-referer?mock-param=mock-value'
+		before(async () => {
+			await database.seed(dashboard, 'basic');
+			response = await request.post('/login', {
+				headers: {
+					'Content-Type': 'application/x-www-form-urlencoded'
+				},
+				body: querystring.stringify({
+					email: 'admin@example.com',
+					password: 'password',
+					referer: '/mock-referer?mock-param=mock-value'
+				})
 			});
 		});
 
 		it('responds with a 302 status', () => {
-			return request.expect(302);
+			assert.strictEqual(response.statusCode, 302);
 		});
 
 		it('responds with a Location header pointing to the referring page', () => {
-			return request.expect('Location', '/mock-referer?mock-param=mock-value');
+			assert.strictEqual(response.headers.location, '/mock-referer?mock-param=mock-value');
 		});
 
 		it('responds with plain text', () => {
-			return request.expect('Content-Type', /text\/plain/);
+			assert.include(response.headers['content-type'], 'text/plain');
 		});
 
 	});
 
 	describe('when the login email address does not exist', () => {
 
-		beforeEach(() => {
-			request.send({
-				email: 'notauser@example.com',
-				password: 'password'
+		before(async () => {
+			await database.seed(dashboard, 'basic');
+			response = await request.post('/login', {
+				headers: {
+					'Content-Type': 'application/x-www-form-urlencoded'
+				},
+				body: querystring.stringify({
+					email: 'notauser@example.com',
+					password: 'password'
+				})
 			});
 		});
 
 		it('does not creates a login session', async () => {
-			const response = await request.then();
 			const sessions = await dashboard.database.knex.select('*').from('sessions').limit(1);
 			assert.lengthEquals(sessions, 0);
 			assert.isUndefined(response.headers['set-cookie']);
 		});
 
 		it('responds with a 401 status', () => {
-			return request.expect(401);
+			assert.strictEqual(response.statusCode, 401);
 		});
 
 		it('responds with HTML', () => {
-			return request.expect('Content-Type', /text\/html/);
+			assert.include(response.headers['content-type'], 'text/html');
 		});
 
-		describe('HTML response', () => {
-			let dom;
-			let errors;
-			let form;
+		it('responds with an error message', () => {
+			const errors = response.body.document.querySelectorAll('[data-test=login-form] [data-test=alert-error]');
+			assert.lengthEquals(errors, 1);
+			assert.match(errors[0].textContent, /email address is not registered, or password is incorrect/i);
+		});
 
-			beforeEach(async () => {
-				dom = new JSDOM((await request.then()).text);
-				form = dom.window.document.querySelector('[data-test=login-form]');
-				errors = form.querySelectorAll('[data-test=alert-error]');
-			});
+		it('responds with a login form that has a pre-filled email field', () => {
+			const form = response.body.document.querySelector('[data-test=login-form]');
+			assert.isNotNull(form);
+			assert.strictEqual(form.getAttribute('action'), '/login');
+			assert.strictEqual(form.getAttribute('method'), 'post');
 
-			it('contains an error message', () => {
-				assert.lengthEquals(errors, 1);
-				assert.match(errors[0].textContent, /email address is not registered, or password is incorrect/i);
-			});
+			const emailField = form.querySelector('input[name="email"]');
+			assert.strictEqual(emailField.getAttribute('type'), 'email');
+			assert.strictEqual(emailField.getAttribute('value'), 'notauser@example.com');
 
-			it('contains a login form', () => {
-				assert.isNotNull(form);
-				assert.strictEqual(form.getAttribute('action'), '/login');
-				assert.strictEqual(form.getAttribute('method'), 'post');
-				assert.strictEqual(form.getAttribute('enctype'), 'application/x-www-form-urlencoded');
-			});
-
-			it('fills the email address field but not the password', () => {
-				const emailField = form.querySelector('input[name="email"]');
-				assert.strictEqual(emailField.getAttribute('value'), 'notauser@example.com');
-				const passwordField = form.querySelector('input[name="password"]');
-				assert.strictEqual(passwordField.getAttribute('value'), '');
-			});
-
+			const passwordField = form.querySelector('input[name="password"]');
+			assert.strictEqual(passwordField.getAttribute('type'), 'password');
+			assert.strictEqual(passwordField.getAttribute('value'), '');
 		});
 
 	});
 
 	describe('when the login password is incorrect', () => {
 
-		beforeEach(() => {
-			request.send({
-				email: 'admin@example.com',
-				password: 'incorrectpassword'
+		before(async () => {
+			await database.seed(dashboard, 'basic');
+			response = await request.post('/login', {
+				headers: {
+					'Content-Type': 'application/x-www-form-urlencoded'
+				},
+				body: querystring.stringify({
+					email: 'admin@example.com',
+					password: 'incorrectpassword'
+				})
 			});
 		});
 
 		it('does not creates a login session', async () => {
-			const response = await request.then();
 			const sessions = await dashboard.database.knex.select('*').from('sessions').limit(1);
 			assert.lengthEquals(sessions, 0);
 			assert.isUndefined(response.headers['set-cookie']);
 		});
 
 		it('responds with a 401 status', () => {
-			return request.expect(401);
+			assert.strictEqual(response.statusCode, 401);
 		});
 
 		it('responds with HTML', () => {
-			return request.expect('Content-Type', /text\/html/);
+			assert.include(response.headers['content-type'], 'text/html');
 		});
 
-		describe('HTML response', () => {
-			let dom;
-			let errors;
-			let form;
+		it('responds with an error message', () => {
+			const errors = response.body.document.querySelectorAll('[data-test=login-form] [data-test=alert-error]');
+			assert.lengthEquals(errors, 1);
+			assert.match(errors[0].textContent, /email address is not registered, or password is incorrect/i);
+		});
 
-			beforeEach(async () => {
-				dom = new JSDOM((await request.then()).text);
-				form = dom.window.document.querySelector('[data-test=login-form]');
-				errors = form.querySelectorAll('[data-test=alert-error]');
-			});
+		it('responds with a login form that has a pre-filled email field', () => {
+			const form = response.body.document.querySelector('[data-test=login-form]');
+			assert.isNotNull(form);
+			assert.strictEqual(form.getAttribute('action'), '/login');
+			assert.strictEqual(form.getAttribute('method'), 'post');
 
-			it('contains an error message', () => {
-				assert.lengthEquals(errors, 1);
-				assert.match(errors[0].textContent, /email address is not registered, or password is incorrect/i);
-			});
+			const emailField = form.querySelector('input[name="email"]');
+			assert.strictEqual(emailField.getAttribute('type'), 'email');
+			assert.strictEqual(emailField.getAttribute('value'), 'admin@example.com');
 
-			it('contains a login form', () => {
-				assert.isNotNull(form);
-				assert.strictEqual(form.getAttribute('action'), '/login');
-				assert.strictEqual(form.getAttribute('method'), 'post');
-				assert.strictEqual(form.getAttribute('enctype'), 'application/x-www-form-urlencoded');
-			});
-
-			it('fills the email address field but not the password', () => {
-				const emailField = form.querySelector('input[name="email"]');
-				assert.strictEqual(emailField.getAttribute('value'), 'admin@example.com');
-				const passwordField = form.querySelector('input[name="password"]');
-				assert.strictEqual(passwordField.getAttribute('value'), '');
-			});
-
+			const passwordField = form.querySelector('input[name="password"]');
+			assert.strictEqual(passwordField.getAttribute('type'), 'password');
+			assert.strictEqual(passwordField.getAttribute('value'), '');
 		});
 
 	});

--- a/test/integration/routes/front-end/settings-password.test.js
+++ b/test/integration/routes/front-end/settings-password.test.js
@@ -4,47 +4,43 @@ const assert = require('proclaim');
 const auth = require('../../helpers/auth');
 const bcrypt = require('bcrypt');
 const database = require('../../helpers/database');
-const {JSDOM} = require('jsdom');
+const querystring = require('querystring');
+let response;
 
 describe('GET /settings/password', () => {
-	let request;
+
+	before(async () => {
+		await database.seed(dashboard, 'basic');
+	});
 
 	describe('when a user is logged in', () => {
 
-		beforeEach(async () => {
-			await database.seed(dashboard, 'basic');
-			await auth.login('read@example.com', 'password');
-			request = agent.get('/settings/password');
-		});
+		describe('when everything is valid', () => {
 
-		it('responds with a 200 status', () => {
-			return request.expect(200);
-		});
-
-		it('responds with HTML', () => {
-			return request.expect('Content-Type', /text\/html/);
-		});
-
-		describe('HTML response', () => {
-			let dom;
-			let errors;
-			let form;
-
-			beforeEach(async () => {
-				dom = new JSDOM((await request.then()).text);
-				form = dom.window.document.querySelector('[data-test=password-form]');
-				errors = form.querySelectorAll('[data-test=alert-error]');
+			before(async () => {
+				response = await request.get('/settings/password', {
+					jar: await auth.getCookieJar('read@example.com', 'password')
+				});
 			});
 
-			it('contains no error messages', () => {
+			it('responds with a 200 status', () => {
+				assert.strictEqual(response.statusCode, 200);
+			});
+
+			it('responds with HTML', () => {
+				assert.include(response.headers['content-type'], 'text/html');
+			});
+
+			it('responds with no error messages', () => {
+				const errors = response.body.document.querySelectorAll('[data-test=password-form] [data-test=alert-error]');
 				assert.lengthEquals(errors, 0);
 			});
 
-			it('contains a password form', () => {
+			it('responds with a password form', () => {
+				const form = response.body.document.querySelector('[data-test=password-form]');
 				assert.isNotNull(form);
 				assert.strictEqual(form.getAttribute('action'), '/settings/password');
 				assert.strictEqual(form.getAttribute('method'), 'post');
-				assert.strictEqual(form.getAttribute('enctype'), 'application/x-www-form-urlencoded');
 
 				const currentPasswordField = form.querySelector('input[name="current"]');
 				assert.strictEqual(currentPasswordField.getAttribute('type'), 'password');
@@ -65,20 +61,17 @@ describe('GET /settings/password', () => {
 
 	describe('when no user is logged in', () => {
 
-		beforeEach(async () => {
-			await database.seed(dashboard, 'basic');
-			request = agent.get('/settings/password');
+		before(async () => {
+			response = await request.get('/settings/password');
 		});
 
 		it('responds with a 401 status', () => {
-			return request.expect(401);
+			assert.strictEqual(response.statusCode, 401);
 		});
 
-		describe('HTML response', () => {
-			it('contains a 401 error message', async () => {
-				const html = (await request.then()).text;
-				assert.match(html, /must authenticate/i);
-			});
+		it('it responds with an error page', () => {
+			const body = response.body.document.querySelector('body');
+			assert.match(body.innerHTML, /must authenticate/i);
 		});
 
 	});
@@ -86,30 +79,27 @@ describe('GET /settings/password', () => {
 });
 
 describe('POST /settings/password', () => {
-	let request;
 
 	describe('when a user is logged in', () => {
 
-		beforeEach(async () => {
-			await database.seed(dashboard, 'basic');
-			await auth.login('read@example.com', 'password');
-			request = agent
-				.post('/settings/password')
-				.set('Content-Type', 'application/x-www-form-urlencoded');
-		});
-
 		describe('when everything is valid', () => {
 
-			beforeEach(() => {
-				request.send({
-					current: 'password',
-					next: 'new-password',
-					confirm: 'new-password'
+			before(async () => {
+				await database.seed(dashboard, 'basic');
+				response = await request.post('/settings/password', {
+					headers: {
+						'Content-Type': 'application/x-www-form-urlencoded'
+					},
+					body: querystring.stringify({
+						current: 'password',
+						next: 'new-password',
+						confirm: 'new-password'
+					}),
+					jar: await auth.getCookieJar('read@example.com', 'password')
 				});
 			});
 
 			it('updates the expected user password in the database', async () => {
-				await request.then();
 				const users = await dashboard.database.knex.select('*').from('users').where({
 					email: 'read@example.com'
 				});
@@ -121,31 +111,37 @@ describe('POST /settings/password', () => {
 			});
 
 			it('responds with a 302 status', () => {
-				return request.expect(302);
+				assert.strictEqual(response.statusCode, 302);
 			});
 
 			it('responds with a Location header pointing to the password settings page', () => {
-				return request.expect('Location', '/settings/password');
+				assert.strictEqual(response.headers.location, '/settings/password');
 			});
 
 			it('responds with plain text', () => {
-				return request.expect('Content-Type', /text\/plain/);
+				assert.include(response.headers['content-type'], 'text/plain');
 			});
 
 		});
 
 		describe('when the current password is invalid', () => {
 
-			beforeEach(() => {
-				request.send({
-					current: 'invalid-password',
-					next: 'new-password',
-					confirm: 'new-password'
+			before(async () => {
+				await database.seed(dashboard, 'basic');
+				response = await request.post('/settings/password', {
+					headers: {
+						'Content-Type': 'application/x-www-form-urlencoded'
+					},
+					body: querystring.stringify({
+						current: 'invalid-password',
+						next: 'new-password',
+						confirm: 'new-password'
+					}),
+					jar: await auth.getCookieJar('read@example.com', 'password')
 				});
 			});
 
 			it('does not update the user password in the database', async () => {
-				await request.then();
 				const users = await dashboard.database.knex.select('*').from('users').where({
 					email: 'read@example.com'
 				});
@@ -156,64 +152,58 @@ describe('POST /settings/password', () => {
 			});
 
 			it('responds with a 400 status', () => {
-				return request.expect(400);
+				assert.strictEqual(response.statusCode, 400);
 			});
 
 			it('responds with HTML', () => {
-				return request.expect('Content-Type', /text\/html/);
+				assert.include(response.headers['content-type'], 'text/html');
 			});
 
-			describe('HTML response', () => {
-				let dom;
-				let errors;
-				let form;
+			it('responds with an error message', () => {
+				const errors = response.body.document.querySelectorAll('[data-test=password-form] [data-test=alert-error]');
+				assert.lengthEquals(errors, 1);
+				assert.match(errors[0].textContent, /current password was incorrect/i);
+			});
 
-				beforeEach(async () => {
-					dom = new JSDOM((await request.then()).text);
-					form = dom.window.document.querySelector('[data-test=password-form]');
-					errors = form.querySelectorAll('[data-test=alert-error]');
-				});
+			it('responds with a password form', () => {
+				const form = response.body.document.querySelector('[data-test=password-form]');
+				assert.isNotNull(form);
+				assert.strictEqual(form.getAttribute('action'), '/settings/password');
+				assert.strictEqual(form.getAttribute('method'), 'post');
 
-				it('contains an error message', () => {
-					assert.lengthEquals(errors, 1);
-					assert.match(errors[0].textContent, /current password was incorrect/i);
-				});
+				const currentPasswordField = form.querySelector('input[name="current"]');
+				assert.strictEqual(currentPasswordField.getAttribute('type'), 'password');
+				assert.isNull(currentPasswordField.getAttribute('value'));
 
-				it('contains a password form', () => {
-					assert.isNotNull(form);
-					assert.strictEqual(form.getAttribute('action'), '/settings/password');
-					assert.strictEqual(form.getAttribute('method'), 'post');
-					assert.strictEqual(form.getAttribute('enctype'), 'application/x-www-form-urlencoded');
+				const nextPasswordField = form.querySelector('input[name="next"]');
+				assert.strictEqual(nextPasswordField.getAttribute('type'), 'password');
+				assert.isNull(nextPasswordField.getAttribute('value'));
 
-					const currentPasswordField = form.querySelector('input[name="current"]');
-					assert.strictEqual(currentPasswordField.getAttribute('type'), 'password');
-					assert.isNull(currentPasswordField.getAttribute('value'));
-
-					const nextPasswordField = form.querySelector('input[name="next"]');
-					assert.strictEqual(nextPasswordField.getAttribute('type'), 'password');
-					assert.isNull(nextPasswordField.getAttribute('value'));
-
-					const confirmPasswordField = form.querySelector('input[name="confirm"]');
-					assert.strictEqual(confirmPasswordField.getAttribute('type'), 'password');
-					assert.isNull(confirmPasswordField.getAttribute('value'));
-				});
-
+				const confirmPasswordField = form.querySelector('input[name="confirm"]');
+				assert.strictEqual(confirmPasswordField.getAttribute('type'), 'password');
+				assert.isNull(confirmPasswordField.getAttribute('value'));
 			});
 
 		});
 
 		describe('when the new password is invalid', () => {
 
-			beforeEach(() => {
-				request.send({
-					current: 'password',
-					next: 'new',
-					confirm: 'new'
+			before(async () => {
+				await database.seed(dashboard, 'basic');
+				response = await request.post('/settings/password', {
+					headers: {
+						'Content-Type': 'application/x-www-form-urlencoded'
+					},
+					body: querystring.stringify({
+						current: 'password',
+						next: 'new',
+						confirm: 'new'
+					}),
+					jar: await auth.getCookieJar('read@example.com', 'password')
 				});
 			});
 
 			it('does not update the user password in the database', async () => {
-				await request.then();
 				const users = await dashboard.database.knex.select('*').from('users').where({
 					email: 'read@example.com'
 				});
@@ -224,64 +214,58 @@ describe('POST /settings/password', () => {
 			});
 
 			it('responds with a 400 status', () => {
-				return request.expect(400);
+				assert.strictEqual(response.statusCode, 400);
 			});
 
 			it('responds with HTML', () => {
-				return request.expect('Content-Type', /text\/html/);
+				assert.include(response.headers['content-type'], 'text/html');
 			});
 
-			describe('HTML response', () => {
-				let dom;
-				let errors;
-				let form;
+			it('responds with an error message', () => {
+				const errors = response.body.document.querySelectorAll('[data-test=password-form] [data-test=alert-error]');
+				assert.lengthEquals(errors, 1);
+				assert.match(errors[0].textContent, /length must be at least 6/i);
+			});
 
-				beforeEach(async () => {
-					dom = new JSDOM((await request.then()).text);
-					form = dom.window.document.querySelector('[data-test=password-form]');
-					errors = form.querySelectorAll('[data-test=alert-error]');
-				});
+			it('responds with a password form', () => {
+				const form = response.body.document.querySelector('[data-test=password-form]');
+				assert.isNotNull(form);
+				assert.strictEqual(form.getAttribute('action'), '/settings/password');
+				assert.strictEqual(form.getAttribute('method'), 'post');
 
-				it('contains an error message', () => {
-					assert.lengthEquals(errors, 1);
-					assert.match(errors[0].textContent, /length must be at least 6/i);
-				});
+				const currentPasswordField = form.querySelector('input[name="current"]');
+				assert.strictEqual(currentPasswordField.getAttribute('type'), 'password');
+				assert.isNull(currentPasswordField.getAttribute('value'));
 
-				it('contains a password form', () => {
-					assert.isNotNull(form);
-					assert.strictEqual(form.getAttribute('action'), '/settings/password');
-					assert.strictEqual(form.getAttribute('method'), 'post');
-					assert.strictEqual(form.getAttribute('enctype'), 'application/x-www-form-urlencoded');
+				const nextPasswordField = form.querySelector('input[name="next"]');
+				assert.strictEqual(nextPasswordField.getAttribute('type'), 'password');
+				assert.isNull(nextPasswordField.getAttribute('value'));
 
-					const currentPasswordField = form.querySelector('input[name="current"]');
-					assert.strictEqual(currentPasswordField.getAttribute('type'), 'password');
-					assert.isNull(currentPasswordField.getAttribute('value'));
-
-					const nextPasswordField = form.querySelector('input[name="next"]');
-					assert.strictEqual(nextPasswordField.getAttribute('type'), 'password');
-					assert.isNull(nextPasswordField.getAttribute('value'));
-
-					const confirmPasswordField = form.querySelector('input[name="confirm"]');
-					assert.strictEqual(confirmPasswordField.getAttribute('type'), 'password');
-					assert.isNull(confirmPasswordField.getAttribute('value'));
-				});
-
+				const confirmPasswordField = form.querySelector('input[name="confirm"]');
+				assert.strictEqual(confirmPasswordField.getAttribute('type'), 'password');
+				assert.isNull(confirmPasswordField.getAttribute('value'));
 			});
 
 		});
 
 		describe('when the confirmed password does not match the new password', () => {
 
-			beforeEach(() => {
-				request.send({
-					current: 'password',
-					next: 'new-password',
-					confirm: 'password-new'
+			before(async () => {
+				await database.seed(dashboard, 'basic');
+				response = await request.post('/settings/password', {
+					headers: {
+						'Content-Type': 'application/x-www-form-urlencoded'
+					},
+					body: querystring.stringify({
+						current: 'password',
+						next: 'new-password',
+						confirm: 'password-new'
+					}),
+					jar: await auth.getCookieJar('read@example.com', 'password')
 				});
 			});
 
 			it('does not update the user password in the database', async () => {
-				await request.then();
 				const users = await dashboard.database.knex.select('*').from('users').where({
 					email: 'read@example.com'
 				});
@@ -292,48 +276,36 @@ describe('POST /settings/password', () => {
 			});
 
 			it('responds with a 400 status', () => {
-				return request.expect(400);
+				assert.strictEqual(response.statusCode, 400);
 			});
 
 			it('responds with HTML', () => {
-				return request.expect('Content-Type', /text\/html/);
+				assert.include(response.headers['content-type'], 'text/html');
 			});
 
-			describe('HTML response', () => {
-				let dom;
-				let errors;
-				let form;
+			it('responds with an error message', () => {
+				const errors = response.body.document.querySelectorAll('[data-test=password-form] [data-test=alert-error]');
+				assert.lengthEquals(errors, 1);
+				assert.match(errors[0].textContent, /passwords do not match/i);
+			});
 
-				beforeEach(async () => {
-					dom = new JSDOM((await request.then()).text);
-					form = dom.window.document.querySelector('[data-test=password-form]');
-					errors = form.querySelectorAll('[data-test=alert-error]');
-				});
+			it('responds with a password form', () => {
+				const form = response.body.document.querySelector('[data-test=password-form]');
+				assert.isNotNull(form);
+				assert.strictEqual(form.getAttribute('action'), '/settings/password');
+				assert.strictEqual(form.getAttribute('method'), 'post');
 
-				it('contains an error message', () => {
-					assert.lengthEquals(errors, 1);
-					assert.match(errors[0].textContent, /passwords do not match/i);
-				});
+				const currentPasswordField = form.querySelector('input[name="current"]');
+				assert.strictEqual(currentPasswordField.getAttribute('type'), 'password');
+				assert.isNull(currentPasswordField.getAttribute('value'));
 
-				it('contains a password form', () => {
-					assert.isNotNull(form);
-					assert.strictEqual(form.getAttribute('action'), '/settings/password');
-					assert.strictEqual(form.getAttribute('method'), 'post');
-					assert.strictEqual(form.getAttribute('enctype'), 'application/x-www-form-urlencoded');
+				const nextPasswordField = form.querySelector('input[name="next"]');
+				assert.strictEqual(nextPasswordField.getAttribute('type'), 'password');
+				assert.isNull(nextPasswordField.getAttribute('value'));
 
-					const currentPasswordField = form.querySelector('input[name="current"]');
-					assert.strictEqual(currentPasswordField.getAttribute('type'), 'password');
-					assert.isNull(currentPasswordField.getAttribute('value'));
-
-					const nextPasswordField = form.querySelector('input[name="next"]');
-					assert.strictEqual(nextPasswordField.getAttribute('type'), 'password');
-					assert.isNull(nextPasswordField.getAttribute('value'));
-
-					const confirmPasswordField = form.querySelector('input[name="confirm"]');
-					assert.strictEqual(confirmPasswordField.getAttribute('type'), 'password');
-					assert.isNull(confirmPasswordField.getAttribute('value'));
-				});
-
+				const confirmPasswordField = form.querySelector('input[name="confirm"]');
+				assert.strictEqual(confirmPasswordField.getAttribute('type'), 'password');
+				assert.isNull(confirmPasswordField.getAttribute('value'));
 			});
 
 		});
@@ -342,20 +314,17 @@ describe('POST /settings/password', () => {
 
 	describe('when no user is logged in', () => {
 
-		beforeEach(async () => {
-			await database.seed(dashboard, 'basic');
-			request = agent.get('/settings/password');
+		before(async () => {
+			response = await request.get('/settings/password');
 		});
 
 		it('responds with a 401 status', () => {
-			return request.expect(401);
+			assert.strictEqual(response.statusCode, 401);
 		});
 
-		describe('HTML response', () => {
-			it('contains a 401 error message', async () => {
-				const html = (await request.then()).text;
-				assert.match(html, /must authenticate/i);
-			});
+		it('it responds with an error page', () => {
+			const body = response.body.document.querySelector('body');
+			assert.match(body.innerHTML, /must authenticate/i);
 		});
 
 	});

--- a/test/integration/setup.test.js
+++ b/test/integration/setup.test.js
@@ -1,9 +1,12 @@
 'use strict';
 
 const Dashboard = require('../..');
-const supertest = require('supertest');
+const {JSDOM} = require('jsdom');
+const request = require('request-promise-native');
 
 before(async () => {
+
+	// Create a test dashboard and start it
 	const dashboard = global.dashboard = new Dashboard({
 		databaseConnectionString: process.env.TEST_DATABASE || 'postgres://localhost:5432/pa11y_sidekick_test',
 		environment: 'test',
@@ -18,7 +21,26 @@ before(async () => {
 		sessionSecret: 'test'
 	});
 	await dashboard.start();
-	global.agent = supertest.agent(dashboard.app);
+
+	// Set up a pre-configured request function
+	global.request = request.defaults({
+		baseUrl: dashboard.address,
+		followRedirect: false,
+		resolveWithFullResponse: true,
+		simple: false,
+		transform: (body, response) => {
+			if (response.headers['content-type']) {
+				if (response.headers['content-type'].includes('text/html')) {
+					const dom = new JSDOM(response.body);
+					response.body = dom.window;
+				} else if (response.headers['content-type'].includes('application/json')) {
+					response.body = JSON.parse(response.body);
+				}
+			}
+			return response;
+		}
+	});
+
 });
 
 after(() => {


### PR DESCRIPTION
This simplifies the integration tests a lot, and allows us to more
easily replace the underlying request code. Also because we're now able
to use `before` rather than `beforeEach` in a lot of places, the tests
take ~25% of the time to run.