### PR TITLE
Make a start on adding sites to the dashboard

### DIFF
--- a/controller/api-v1/index.js
+++ b/controller/api-v1/index.js
@@ -4,6 +4,7 @@ const authWithKey = require('../../lib/middleware/auth-with-key');
 const express = require('express');
 const initDocsController = require('./docs');
 const initMeController = require('./me');
+const initSitesController = require('./sites');
 const initUsersController = require('./users');
 const notFound = require('../../lib/middleware/not-found');
 
@@ -35,6 +36,7 @@ function initApiV1Contoller(dashboard) {
 
 	// Mount routes
 	initDocsController(dashboard, router);
+	initSitesController(dashboard, router);
 	initUsersController(dashboard, router);
 	initMeController(dashboard, router);
 

--- a/controller/api-v1/sites.js
+++ b/controller/api-v1/sites.js
@@ -1,0 +1,92 @@
+'use strict';
+
+const express = require('express');
+// const httpError = require('http-errors');
+const requirePermission = require('../../lib/middleware/require-permission');
+
+/**
+ * Initialise the sites controller.
+ * @param {Dashboard} dashboard - A dashboard instance.
+ * @param {Object} router - The API Express router.
+ * @returns {undefined} Nothing
+ */
+function initSitesController(dashboard, router) {
+	const Site = dashboard.model.Site;
+
+	// Get a list of all sites
+	router.get('/sites', requirePermission('read'), async (request, response, next) => {
+		try {
+			response.send(await Site.fetchAll());
+		} catch (error) {
+			return next(error);
+		}
+	});
+
+	// Create a new site
+	router.post('/sites', requirePermission('write'), express.json(), async (request, response, next) => {
+		try {
+			const site = await Site.create({
+				name: request.body.name,
+				base_url: request.body.baseUrl,
+				is_runnable: request.body.isRunnable,
+				is_scheduled: request.body.isScheduled,
+				schedule: request.body.schedule,
+				pa11y_config: request.body.pa11yConfig
+			});
+			response.status(201).send(site);
+		} catch (error) {
+			return next(error);
+		}
+	});
+
+	// Get a single site by ID
+	router.get('/sites/:siteId', requirePermission('read'), async (request, response, next) => {
+		try {
+			const site = await Site.fetchOneById(request.params.siteId);
+			if (!site) {
+				return next();
+			}
+			response.send(site);
+		} catch (error) {
+			return next(error);
+		}
+	});
+
+	// Update a site by ID
+	router.patch('/sites/:siteId', requirePermission('write'), express.json(), async (request, response, next) => {
+		try {
+			const site = await Site.fetchOneById(request.params.siteId);
+			if (!site) {
+				return next();
+			}
+			await site.update({
+				name: request.body.name,
+				base_url: request.body.baseUrl,
+				is_runnable: request.body.isRunnable,
+				is_scheduled: request.body.isScheduled,
+				schedule: request.body.schedule,
+				pa11y_config: request.body.pa11yConfig
+			});
+			response.status(200).send(site);
+		} catch (error) {
+			return next(error);
+		}
+	});
+
+	// Delete a site by ID
+	router.delete('/sites/:siteId', requirePermission('delete'), async (request, response, next) => {
+		try {
+			const site = await Site.fetchOneById(request.params.siteId);
+			if (!site) {
+				return next();
+			}
+			await site.destroy();
+			response.status(204).send({});
+		} catch (error) {
+			return next(error);
+		}
+	});
+
+}
+
+module.exports = initSitesController;

--- a/controller/front-end/docs.js
+++ b/controller/front-end/docs.js
@@ -14,6 +14,9 @@ function initDocsController(dashboard, router) {
 	router.get('/docs/api/v1', requirePermission('read'), (request, response) => {
 		response.render('template/docs/api-v1');
 	});
+	router.get('/docs/api/v1/sites', requirePermission('read'), (request, response) => {
+		response.render('template/docs/api-v1-sites');
+	});
 	router.get('/docs/api/v1/users', requirePermission('read'), (request, response) => {
 		response.render('template/docs/api-v1-users');
 	});

--- a/controller/front-end/index.js
+++ b/controller/front-end/index.js
@@ -9,6 +9,7 @@ const initDocsController = require('./docs');
 const initHomeController = require('./home');
 const initSettingsController = require('./settings');
 const initSetupController = require('./setup');
+const initSitesController = require('./sites');
 const notFound = require('../../lib/middleware/not-found');
 const session = require('express-session');
 const SessionStore = require('connect-session-knex')(session);
@@ -20,6 +21,7 @@ const uuid = require('uuid/v4');
  * @returns {Object} An Express router.
  */
 function initFrontEndController(dashboard) {
+	const Setting = dashboard.model.Setting;
 
 	// Create an Express router for the front end
 	const router = new express.Router({
@@ -60,6 +62,7 @@ function initFrontEndController(dashboard) {
 		response.locals.permissions = request.permissions;
 		response.locals.requestPath = request.path;
 		response.locals.requestUrl = request.url;
+		response.locals.publicReadAccess = Setting.get('publicReadAccess');
 		next();
 	});
 
@@ -69,6 +72,7 @@ function initFrontEndController(dashboard) {
 	initHomeController(dashboard, router);
 	initAuthController(dashboard, router);
 	initDocsController(dashboard, router);
+	initSitesController(dashboard, router);
 	initSettingsController(dashboard, router);
 	initAdminController(dashboard, router);
 

--- a/controller/front-end/sites.js
+++ b/controller/front-end/sites.js
@@ -1,0 +1,96 @@
+'use strict';
+
+const express = require('express');
+const requirePermission = require('../../lib/middleware/require-permission');
+
+/**
+ * Initialise the sites controller.
+ * @param {Dashboard} dashboard - A dashboard instance.
+ * @param {Object} router - The front end Express router.
+ * @returns {undefined} Nothing
+ */
+function initSitesController(dashboard, router) {
+	const Site = dashboard.model.Site;
+
+	// TODO write integration tests for these routes
+
+	// List of all sites
+	router.get('/sites', requirePermission('read'), async (request, response) => {
+		response.render('template/sites/sites', {
+			sites: (await Site.fetchAll()).serialize()
+		});
+	});
+
+	// Get a single site
+	router.get('/sites/:siteId', requirePermission('read'), async (request, response, next) => {
+		try {
+			const site = await Site.fetchOneById(request.params.siteId);
+			if (!site) {
+				return next();
+			}
+			response.render('template/sites/site', {
+				site: site.serialize(),
+				form: {
+					site: {
+						created: request.flash.get('form.site.created')
+					}
+				}
+			});
+		} catch (error) {
+			return next(error);
+		}
+	});
+
+	// Display the new site page
+	router.get('/sites/new', requirePermission('write'), (request, response) => {
+		response.render('template/sites/new-site', {
+			form: {
+				site: {}
+			}
+		});
+	});
+
+	// Create a new site
+	router.post('/sites/new', requirePermission('write'), express.urlencoded({extended: false}), async (request, response, next) => {
+		try {
+
+			// TODO check Pa11y config for JSON errors
+			// and pass into the create method
+
+			// Attempt to create a site
+			const site = await Site.create({
+				name: request.body.name,
+				base_url: request.body.baseUrl,
+				is_runnable: request.body.isRunnable,
+				is_scheduled: request.body.isScheduled,
+				schedule: request.body.schedule
+			});
+
+			// Redirect to the site page
+			request.flash.set('form.site.created', {
+				name: request.body.name
+			});
+			response.redirect(`/sites/${site.get('id')}`);
+
+		} catch (error) {
+			if (error.name === 'ValidationError') {
+				return response.status(400).render('template/sites/new-site', {
+					form: {
+						site: {
+							name: request.body.name,
+							baseUrl: request.body.baseUrl,
+							isRunnable: request.body.isRunnable,
+							isScheduled: request.body.isScheduled,
+							schedule: request.body.schedule,
+							errors: error.details.map(detail => detail.message)
+						}
+					}
+				});
+			}
+			return next(error);
+		}
+	});
+
+}
+
+module.exports = initSitesController;

--- a/data/migration/20180217203355_sites.js
+++ b/data/migration/20180217203355_sites.js
@@ -1,0 +1,27 @@
+'use strict';
+
+exports.up = async database => {
+
+	// Create the sites table
+	await database.schema.createTable('sites', table => {
+
+		// Meta information
+		table.string('id').unique().primary();
+		table.timestamp('created_at').defaultTo(database.fn.now());
+		table.timestamp('updated_at').defaultTo(database.fn.now());
+
+		// Site information
+		table.string('name').notNullable();
+		table.string('base_url').notNullable();
+		table.boolean('is_runnable').notNullable().defaultTo(true);
+		table.boolean('is_scheduled').notNullable().defaultTo(false);
+		table.string('schedule');
+		table.json('pa11y_config').notNullable().defaultTo('{}');
+
+	});
+
+};
+
+exports.down = async database => {
+	await database.schema.dropTable('sites');
+};

--- a/data/seed/demo/site-pa11y-github.js
+++ b/data/seed/demo/site-pa11y-github.js
@@ -1,0 +1,19 @@
+'use strict';
+
+// Pa11y website details
+exports.seed = async database => {
+
+	// Insert demo site: github.com/pa11y/pa11y
+	await database('sites').insert([
+		{
+			id: 'r1BzElDDG',
+			name: 'Pa11y GitHub Repo',
+			base_url: 'https://github.com/pa11y/pa11y',
+			is_runnable: true,
+			is_scheduled: false,
+			schedule: null,
+			pa11y_config: JSON.stringify({})
+		}
+	]);
+
+};

--- a/data/seed/demo/site-pa11y.js
+++ b/data/seed/demo/site-pa11y.js
@@ -1,0 +1,19 @@
+'use strict';
+
+// Pa11y website details
+exports.seed = async database => {
+
+	// Insert demo site: pa11y.org
+	await database('sites').insert([
+		{
+			id: 'ByXMzeDwf',
+			name: 'Pa11y Website',
+			base_url: 'http://pa11y.org/',
+			is_runnable: true,
+			is_scheduled: false,
+			schedule: null,
+			pa11y_config: JSON.stringify({})
+		}
+	]);
+
+};

--- a/lib/dashboard.js
+++ b/lib/dashboard.js
@@ -11,6 +11,7 @@ const initApiV1Controller = require('../controller/api-v1');
 const initFrontEndController = require('../controller/front-end');
 const initKeyModel = require('../model/key');
 const initSettingModel = require('../model/setting');
+const initSiteModel = require('../model/site');
 const initUserModel = require('../model/user');
 const knex = require('knex');
 const morgan = require('morgan');
@@ -46,6 +47,7 @@ class Dashboard {
 		this.model = {
 			Key: initKeyModel(this),
 			Setting: initSettingModel(this),
+			Site: initSiteModel(this),
 			User: initUserModel(this)
 		};
 

--- a/model/site.js
+++ b/model/site.js
@@ -1,0 +1,156 @@
+'use strict';
+
+const joi = require('joi');
+const shortid = require('shortid');
+
+/**
+ * Initialise the Site model.
+ * @param {Dashboard} dashboard - A dashboard instance.
+ * @returns {Model} A Bookshelf model.
+ */
+function initSiteModel(dashboard) {
+
+	// Model validation schema
+	const schema = joi.object().keys({
+		name: joi.string().min(1).required(),
+		base_url: joi.string().uri({
+			scheme: [
+				'http',
+				'https'
+			]
+		}).required(),
+		is_runnable: joi.boolean().required(),
+		is_scheduled: joi.boolean().required(),
+		schedule: [joi.string().min(1), null],
+		pa11y_config: joi.object()
+	});
+
+	// Model prototypal methods
+	const Site = dashboard.database.Model.extend({
+		tableName: 'sites',
+
+		// Model initialization
+		initialize() {
+
+			// When a model is created...
+			this.on('creating', () => {
+
+				// Fill out automatic fields
+				this.attributes.id = shortid.generate();
+				this.attributes.created_at = new Date();
+
+			});
+
+			// When a model is saved...
+			this.on('saving', async () => {
+
+				// Fill out automatic fields
+				this.attributes.updated_at = new Date();
+
+				// Validate the model
+				await this.validateSave();
+
+				// Encode the Pa11y config if it's changed
+				if (this.hasChanged('pa11y_config')) {
+					this.attributes.pa11y_config = JSON.stringify(this.attributes.pa11y_config);
+				}
+
+			});
+
+		},
+
+		// Validate the model before saving
+		validateSave() {
+			return new Promise((resolve, reject) => {
+				// Validate against the schema
+				joi.validate(this.attributes, schema, {
+					abortEarly: false,
+					allowUnknown: true
+				}, error => {
+					if (error) {
+						return reject(error);
+					}
+					resolve();
+				});
+			});
+		},
+
+		// Update the site with user-provided data
+		async update(data) {
+			if (data.name !== undefined) {
+				this.set('name', data.name);
+			}
+			if (data.base_url !== undefined) {
+				this.set('base_url', data.base_url);
+			}
+			if (data.is_runnable !== undefined) {
+				this.set('is_runnable', Boolean(data.is_runnable));
+			}
+			if (data.is_scheduled !== undefined) {
+				this.set('is_scheduled', Boolean(data.is_scheduled));
+			}
+			if (data.schedule !== undefined) {
+				this.set('schedule', data.schedule);
+			}
+			if (data.pa11y_config !== undefined) {
+				this.set('pa11y_config', data.pa11y_config);
+			}
+			await this.save();
+			return this;
+		},
+
+		// Override default serialization so we can control output
+		serialize() {
+			return {
+				id: this.get('id'),
+				name: this.get('name'),
+				baseUrl: this.get('base_url'),
+				isRunnable: this.get('is_runnable'),
+				isScheduled: this.get('is_scheduled'),
+				schedule: this.get('schedule'),
+				pa11yConfig: this.get('pa11y_config'),
+				meta: {
+					dateCreated: this.get('created_at'),
+					dateUpdated: this.get('updated_at')
+				}
+			};
+		}
+
+	// Model static methods
+	}, {
+
+		// Create a site with user-provided data
+		async create(data) {
+			const site = new Site({
+				name: data.name,
+				base_url: data.base_url,
+				is_runnable: Boolean(data.is_runnable),
+				is_scheduled: Boolean(data.is_scheduled),
+				schedule: data.schedule || null,
+				pa11y_config: data.pa11y_config
+			});
+			await site.save();
+			return site;
+		},
+
+		// Fetch all sites
+		fetchAll() {
+			return Site.collection().query(qb => {
+				qb.orderBy('name', 'asc');
+				qb.orderBy('created_at', 'asc');
+			}).fetch();
+		},
+
+		// Fetch a site by id
+		fetchOneById(siteId) {
+			return Site.collection().query(qb => {
+				qb.where('id', siteId);
+			}).fetchOne();
+		}
+
+	});
+
+	return Site;
+}
+
+module.exports = initSiteModel;

--- a/test/integration/routes/api-v1/sites-(id).test.js
+++ b/test/integration/routes/api-v1/sites-(id).test.js
@@ -1,0 +1,416 @@
+'use strict';
+
+const assert = require('proclaim');
+const database = require('../../helpers/database');
+let response;
+
+describe('GET /api/v1/sites/:siteId', () => {
+
+	before(async () => {
+		await database.seed(dashboard, 'basic');
+	});
+
+	describe('when everything is valid', () => {
+
+		before(async () => {
+			response = await request.get('/api/v1/sites/mock-site-id-1', {
+				headers: {
+					'X-Api-Key': 'mock-read-key',
+					'X-Api-Secret': 'mock-read-secret'
+				}
+			});
+		});
+
+		it('responds with a 200 status', () => {
+			assert.strictEqual(response.statusCode, 200);
+		});
+
+		it('responds with JSON', () => {
+			assert.include(response.headers['content-type'], 'application/json');
+		});
+
+		it('responds with the site details', () => {
+			assert.isObject(response.body);
+			assert.strictEqual(response.body.id, 'mock-site-id-1');
+		});
+
+	});
+
+	describe('when :siteId is not a valid site ID', () => {
+
+		before(async () => {
+			response = await request.get('/api/v1/sites/not-an-id', {
+				headers: {
+					'X-Api-Key': 'mock-read-key',
+					'X-Api-Secret': 'mock-read-secret'
+				}
+			});
+		});
+
+		it('responds with a 404 status', () => {
+			assert.strictEqual(response.statusCode, 404);
+		});
+
+		it('responds with JSON', () => {
+			assert.include(response.headers['content-type'], 'application/json');
+		});
+
+		it('responds with error details', () => {
+			assert.isObject(response.body);
+			assert.isString(response.body.message);
+			assert.strictEqual(response.body.status, 404);
+		});
+
+	});
+
+	describe('when no API credentials are provided', () => {
+
+		before(async () => {
+			response = await request.get('/api/v1/sites/mock-site-id-1');
+		});
+
+		it('responds with a 403 status', () => {
+			assert.strictEqual(response.statusCode, 403);
+		});
+
+		it('responds with JSON', () => {
+			assert.include(response.headers['content-type'], 'application/json');
+		});
+
+		it('responds with error details', () => {
+			assert.isObject(response.body);
+			assert.isString(response.body.message);
+			assert.strictEqual(response.body.status, 403);
+		});
+
+	});
+
+	describe('when the provided API key does not have the required permissions', () => {
+
+		before(async () => {
+			response = await request.get('/api/v1/sites/mock-site-id-1', {
+				headers: {
+					'X-Api-Key': 'mock-noaccess-key',
+					'X-Api-Secret': 'mock-noaccess-secret'
+				}
+			});
+		});
+
+		it('responds with a 403 status', () => {
+			assert.strictEqual(response.statusCode, 403);
+		});
+
+		it('responds with JSON', () => {
+			assert.include(response.headers['content-type'], 'application/json');
+		});
+
+		it('responds with error details', () => {
+			assert.isObject(response.body);
+			assert.isString(response.body.message);
+			assert.strictEqual(response.body.status, 403);
+		});
+
+	});
+
+	describe('when the public read access setting is enabled', () => {
+
+		before(async () => {
+			await database.seed(dashboard, 'no-auth');
+			response = await request.get('/api/v1/sites/mock-site-id-1');
+		});
+
+		it('responds with a 200 status', () => {
+			assert.strictEqual(response.statusCode, 200);
+		});
+
+		it('responds with JSON', () => {
+			assert.include(response.headers['content-type'], 'application/json');
+		});
+
+	});
+
+});
+
+describe('PATCH /api/v1/sites/:siteId', () => {
+
+	describe('when everything is valid', () => {
+
+		before(async () => {
+			await database.seed(dashboard, 'basic');
+			response = await request.patch('/api/v1/sites/mock-site-id-1', {
+				headers: {
+					'Content-Type': 'application/json',
+					'X-Api-Key': 'mock-write-key',
+					'X-Api-Secret': 'mock-write-secret'
+				},
+				body: JSON.stringify({
+					id: 'extra-property-id',
+					name: 'edited site',
+					baseUrl: 'https://edited-site/',
+					isRunnable: false,
+					isScheduled: false,
+					schedule: null,
+					pa11yConfig: {
+						isUpdated: true
+					}
+				})
+			});
+		});
+
+		it('updates the site in the database', async () => {
+			const sites = await dashboard.database.knex.select('*').from('sites').where({
+				name: 'edited site'
+			});
+			const site = sites[0];
+
+			assert.lengthEquals(sites, 1, 'One site is present');
+			assert.isString(site.id, 'Site has an ID');
+			assert.notStrictEqual(site.id, 'extra-property-id', 'Site ID cannot be set in request');
+			assert.strictEqual(site.name, 'edited site', 'Site has the correct name');
+			assert.strictEqual(site.base_url, 'https://edited-site/', 'Site has the correct base URL');
+			assert.isFalse(site.is_runnable, 'Site is not runnable');
+			assert.isFalse(site.is_scheduled, 'Site is not scheduled');
+			assert.isNull(site.schedule, 'Site has the correct schedule');
+			assert.deepEqual(site.pa11y_config, {
+				isUpdated: true
+			}, 'Site has the correct Pa11y config');
+		});
+
+		it('responds with a 200 status', () => {
+			assert.strictEqual(response.statusCode, 200);
+		});
+
+		it('responds with JSON', () => {
+			assert.include(response.headers['content-type'], 'application/json');
+		});
+
+		it('responds with the updated site details', () => {
+			assert.isObject(response.body);
+			assert.strictEqual(response.body.id, 'mock-site-id-1');
+			assert.strictEqual(response.body.name, 'edited site');
+		});
+
+	});
+
+	describe('when the request has no data set', () => {
+
+		before(async () => {
+			await database.seed(dashboard, 'basic');
+			response = await request.patch('/api/v1/sites/mock-site-id-1', {
+				headers: {
+					'Content-Type': 'application/json',
+					'X-Api-Key': 'mock-write-key',
+					'X-Api-Secret': 'mock-write-secret'
+				},
+				body: JSON.stringify({})
+			});
+		});
+
+		it('responds with a 200 status', () => {
+			assert.strictEqual(response.statusCode, 200);
+		});
+
+	});
+
+	describe('when :siteId is not a valid site ID', () => {
+
+		before(async () => {
+			await database.seed(dashboard, 'basic');
+			response = await request.patch('/api/v1/sites/not-an-id', {
+				headers: {
+					'Content-Type': 'application/json',
+					'X-Api-Key': 'mock-write-key',
+					'X-Api-Secret': 'mock-write-secret'
+				},
+				body: JSON.stringify({})
+			});
+		});
+
+		it('responds with a 404 status', () => {
+			assert.strictEqual(response.statusCode, 404);
+		});
+
+		it('responds with JSON', () => {
+			assert.include(response.headers['content-type'], 'application/json');
+		});
+
+		it('responds with error details', () => {
+			assert.isObject(response.body);
+			assert.isString(response.body.message);
+			assert.strictEqual(response.body.status, 404);
+		});
+
+	});
+
+	describe('when no API credentials are provided', () => {
+
+		before(async () => {
+			await database.seed(dashboard, 'basic');
+			response = await request.patch('/api/v1/sites/mock-site-id-1', {
+				headers: {
+					'Content-Type': 'application/json'
+				},
+				body: JSON.stringify({})
+			});
+		});
+
+		it('responds with a 403 status', () => {
+			assert.strictEqual(response.statusCode, 403);
+		});
+
+		it('responds with JSON', () => {
+			assert.include(response.headers['content-type'], 'application/json');
+		});
+
+		it('responds with error details', () => {
+			assert.isObject(response.body);
+			assert.isString(response.body.message);
+			assert.strictEqual(response.body.status, 403);
+		});
+
+	});
+
+	describe('when the provided API key does not have the required permissions', () => {
+
+		before(async () => {
+			await database.seed(dashboard, 'basic');
+			response = await request.patch('/api/v1/sites/mock-site-id-1', {
+				headers: {
+					'Content-Type': 'application/json',
+					'X-Api-Key': 'mock-read-key',
+					'X-Api-Secret': 'mock-read-secret'
+				},
+				body: JSON.stringify({})
+			});
+		});
+
+		it('responds with a 403 status', () => {
+			assert.strictEqual(response.statusCode, 403);
+		});
+
+		it('responds with JSON', () => {
+			assert.include(response.headers['content-type'], 'application/json');
+		});
+
+		it('responds with error details', () => {
+			assert.isObject(response.body);
+			assert.isString(response.body.message);
+			assert.strictEqual(response.body.status, 403);
+		});
+
+	});
+
+});
+
+describe.only('DELETE /api/v1/sites/:siteId', () => {
+
+	describe('when everything is valid', () => {
+
+		before(async () => {
+			await database.seed(dashboard, 'basic');
+			response = await request.delete('/api/v1/sites/mock-site-id-1', {
+				headers: {
+					'X-Api-Key': 'mock-delete-key',
+					'X-Api-Secret': 'mock-delete-secret'
+				}
+			});
+		});
+
+		it('removes the expected site from the database', async () => {
+			const sites = await dashboard.database.knex.select('*').from('sites').where({
+				id: 'mock-site-id-1'
+			});
+			assert.lengthEquals(sites, 0);
+		});
+
+		it('responds with a 204 status', () => {
+			assert.strictEqual(response.statusCode, 204);
+		});
+
+		it('responds with nothing', () => {
+			assert.isUndefined(response.headers['content-type']);
+			assert.strictEqual(response.body, '');
+		});
+
+	});
+
+	describe('when :siteId is not a valid site ID', () => {
+
+		before(async () => {
+			await database.seed(dashboard, 'basic');
+			response = await request.delete('/api/v1/sites/not-an-id', {
+				headers: {
+					'X-Api-Key': 'mock-delete-key',
+					'X-Api-Secret': 'mock-delete-secret'
+				}
+			});
+		});
+
+		it('responds with a 404 status', () => {
+			assert.strictEqual(response.statusCode, 404);
+		});
+
+		it('responds with JSON', () => {
+			assert.include(response.headers['content-type'], 'application/json');
+		});
+
+		it('responds with error details', () => {
+			assert.isObject(response.body);
+			assert.isString(response.body.message);
+			assert.strictEqual(response.body.status, 404);
+		});
+
+	});
+
+	describe('when no API credentials are provided', () => {
+
+		before(async () => {
+			await database.seed(dashboard, 'basic');
+			response = await request.delete('/api/v1/sites/mock-site-id-1');
+		});
+
+		it('responds with a 403 status', () => {
+			assert.strictEqual(response.statusCode, 403);
+		});
+
+		it('responds with JSON', () => {
+			assert.include(response.headers['content-type'], 'application/json');
+		});
+
+		it('responds with error details', () => {
+			assert.isObject(response.body);
+			assert.isString(response.body.message);
+			assert.strictEqual(response.body.status, 403);
+		});
+
+	});
+
+	describe('when the provided API key does not have the required permissions', () => {
+
+		before(async () => {
+			await database.seed(dashboard, 'basic');
+			response = await request.delete('/api/v1/sites/mock-site-id-1', {
+				headers: {
+					'X-Api-Key': 'mock-write-key',
+					'X-Api-Secret': 'mock-write-secret'
+				}
+			});
+		});
+
+		it('responds with a 403 status', () => {
+			assert.strictEqual(response.statusCode, 403);
+		});
+
+		it('responds with JSON', () => {
+			assert.include(response.headers['content-type'], 'application/json');
+		});
+
+		it('responds with error details', () => {
+			assert.isObject(response.body);
+			assert.isString(response.body.message);
+			assert.strictEqual(response.body.status, 403);
+		});
+
+	});
+
+});

--- a/test/integration/routes/api-v1/sites.test.js
+++ b/test/integration/routes/api-v1/sites.test.js
@@ -1,0 +1,266 @@
+'use strict';
+
+const assert = require('proclaim');
+const database = require('../../helpers/database');
+let response;
+
+describe('GET /api/v1/sites', () => {
+
+	before(async () => {
+		await database.seed(dashboard, 'basic');
+	});
+
+	describe('when everything is valid', () => {
+
+		before(async () => {
+			response = await request.get('/api/v1/sites', {
+				headers: {
+					'X-Api-Key': 'mock-read-key',
+					'X-Api-Secret': 'mock-read-secret'
+				}
+			});
+		});
+
+		it('responds with a 200 status', () => {
+			assert.strictEqual(response.statusCode, 200);
+		});
+
+		it('responds with JSON', () => {
+			assert.include(response.headers['content-type'], 'application/json');
+		});
+
+		it('responds with an array of each site in the database', () => {
+			assert.isArray(response.body);
+			assert.lengthEquals(response.body, 2);
+			assert.isObject(response.body[0]);
+			assert.strictEqual(response.body[0].id, 'mock-site-id-1');
+			assert.isObject(response.body[1]);
+			assert.strictEqual(response.body[1].id, 'mock-site-id-2');
+		});
+
+	});
+
+	describe('when no API credentials are provided', () => {
+
+		before(async () => {
+			response = await request.get('/api/v1/sites');
+		});
+
+		it('responds with a 403 status', () => {
+			assert.strictEqual(response.statusCode, 403);
+		});
+
+		it('responds with JSON', () => {
+			assert.include(response.headers['content-type'], 'application/json');
+		});
+
+		it('responds with error details', () => {
+			assert.isObject(response.body);
+			assert.isString(response.body.message);
+			assert.strictEqual(response.body.status, 403);
+		});
+
+	});
+
+	describe('when the provided API key does not have the required permissions', () => {
+
+		before(async () => {
+			response = await request.get('/api/v1/sites', {
+				headers: {
+					'X-Api-Key': 'mock-noaccess-key',
+					'X-Api-Secret': 'mock-noaccess-secret'
+				}
+			});
+		});
+
+		it('responds with a 403 status', () => {
+			assert.strictEqual(response.statusCode, 403);
+		});
+
+		it('responds with JSON', () => {
+			assert.include(response.headers['content-type'], 'application/json');
+		});
+
+		it('responds with error details', () => {
+			assert.isObject(response.body);
+			assert.isString(response.body.message);
+			assert.strictEqual(response.body.status, 403);
+		});
+
+	});
+
+	describe('when the public read access setting is enabled', () => {
+
+		before(async () => {
+			await database.seed(dashboard, 'no-auth');
+			response = await request.get('/api/v1/sites');
+		});
+
+		it('responds with a 200 status', () => {
+			assert.strictEqual(response.statusCode, 200);
+		});
+
+		it('responds with JSON', () => {
+			assert.include(response.headers['content-type'], 'application/json');
+		});
+
+	});
+
+});
+
+describe('POST /api/v1/sites', () => {
+
+	describe('when everything is valid', () => {
+
+		before(async () => {
+			await database.seed(dashboard, 'basic');
+			response = await request.post('/api/v1/sites', {
+				headers: {
+					'Content-Type': 'application/json',
+					'X-Api-Key': 'mock-write-key',
+					'X-Api-Secret': 'mock-write-secret'
+				},
+				body: JSON.stringify({
+					id: 'extra-property-id',
+					name: 'new site',
+					baseUrl: 'https://new-site/',
+					isRunnable: true,
+					isScheduled: false,
+					schedule: null,
+					pa11yConfig: {
+						isMockConfig: true
+					}
+				})
+			});
+		});
+
+		it('creates a new site in the database', async () => {
+			const sites = await dashboard.database.knex.select('*').from('sites').where({
+				name: 'new site'
+			});
+			const site = sites[0];
+
+			assert.lengthEquals(sites, 1, 'One site is present');
+			assert.isString(site.id, 'Site has an ID');
+			assert.notStrictEqual(site.id, 'extra-property-id', 'Site ID cannot be set in request');
+			assert.strictEqual(site.name, 'edited site', 'Site has the correct name');
+			assert.strictEqual(site.base_url, 'https://new-site/', 'Site has the correct base URL');
+			assert.isTrue(site.is_runnable, 'Site is runnable');
+			assert.isFalse(site.is_scheduled, 'Site is not scheduled');
+			assert.isNull(site.schedule, 'Site has the correct schedule');
+			assert.deepEqual(site.pa11y_config, {
+				isMockConfig: true
+			}, 'Site has the correct Pa11y config');
+		});
+
+		it('responds with a 201 status', () => {
+			assert.strictEqual(response.statusCode, 201);
+		});
+
+		it('responds with JSON', () => {
+			assert.include(response.headers['content-type'], 'application/json');
+		});
+
+		it('responds with the new site details', async () => {
+			const sites = await dashboard.database.knex.select('*').from('sites').where({
+				name: 'new site'
+			});
+
+			assert.isObject(response.body);
+			assert.strictEqual(response.body.id, sites[0].id);
+		});
+
+	});
+
+	describe('when the request does not include a name or baseUrl property', () => {
+
+		before(async () => {
+			await database.seed(dashboard, 'basic');
+			response = await request.post('/api/v1/sites', {
+				headers: {
+					'Content-Type': 'application/json',
+					'X-Api-Key': 'mock-admin-key',
+					'X-Api-Secret': 'mock-admin-secret'
+				},
+				body: JSON.stringify({})
+			});
+		});
+
+		it('responds with a 400 status', () => {
+			assert.strictEqual(response.statusCode, 400);
+		});
+
+		it('responds with JSON', () => {
+			assert.include(response.headers['content-type'], 'application/json');
+		});
+
+		it('responds with error details', () => {
+			assert.isObject(response.body);
+			assert.isString(response.body.message, 'Validation failed');
+			assert.isArray(response.body.validation);
+			assert.deepEqual(response.body.validation, [
+				'"name" is required',
+				'"base_url" is required'
+			]);
+			assert.strictEqual(response.body.status, 400);
+		});
+
+	});
+
+	describe('when no API credentials are provided', () => {
+
+		before(async () => {
+			await database.seed(dashboard, 'basic');
+			response = await request.post('/api/v1/sites', {
+				headers: {
+					'Content-Type': 'application/json'
+				}
+			});
+		});
+
+		it('responds with a 403 status', () => {
+			assert.strictEqual(response.statusCode, 403);
+		});
+
+		it('responds with JSON', () => {
+			assert.include(response.headers['content-type'], 'application/json');
+		});
+
+		it('responds with error details', () => {
+			assert.isObject(response.body);
+			assert.isString(response.body.message);
+			assert.strictEqual(response.body.status, 403);
+		});
+
+	});
+
+	describe('when the provided API key does not have the required permissions', () => {
+
+		before(async () => {
+			await database.seed(dashboard, 'basic');
+			response = await request.post('/api/v1/sites', {
+				headers: {
+					'Content-Type': 'application/json',
+					'X-Api-Key': 'mock-read-key',
+					'X-Api-Secret': 'mock-read-secret'
+				}
+			});
+		});
+
+		it('responds with a 403 status', () => {
+			assert.strictEqual(response.statusCode, 403);
+		});
+
+		it('responds with JSON', () => {
+			assert.include(response.headers['content-type'], 'application/json');
+		});
+
+		it('responds with error details', () => {
+			assert.isObject(response.body);
+			assert.isString(response.body.message);
+			assert.strictEqual(response.body.status, 403);
+		});
+
+	});
+
+});

--- a/test/integration/routes/front-end/docs-api-v1.test.js
+++ b/test/integration/routes/front-end/docs-api-v1.test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const assert = require('proclaim');
+const auth = require('../../helpers/auth');
 const database = require('../../helpers/database');
 let response;
 
@@ -10,10 +11,50 @@ describe('GET /docs/api/v1', () => {
 		await database.seed(dashboard, 'basic');
 	});
 
-	describe('when everything is valid', () => {
+	describe('when a user is logged in', () => {
+
+		before(async () => {
+			response = await request.get('/docs/api/v1', {
+				jar: await auth.getCookieJar('read@example.com', 'password')
+			});
+		});
+
+		it('responds with a 200 status', () => {
+			assert.strictEqual(response.statusCode, 200);
+		});
+
+		it('responds with HTML', () => {
+			assert.include(response.headers['content-type'], 'text/html');
+		});
+
+	});
+
+	describe('when no user is logged in', () => {
 
 		before(async () => {
 			response = await request.get('/docs/api/v1');
+		});
+
+		it('responds with a 403 status', () => {
+			assert.strictEqual(response.statusCode, 403);
+		});
+
+		it('responds with HTML', () => {
+			assert.include(response.headers['content-type'], 'text/html');
+		});
+
+		it('it responds with an error page', () => {
+			const body = response.body.document.querySelector('body');
+			assert.match(body.innerHTML, /not authorised/i);
+		});
+
+	});
+
+	describe('when no user is logged in and the public read access setting is enabled', () => {
+
+		before(async () => {
+			await database.seed(dashboard, 'no-auth');
+			response = await request.get('/');
 		});
 
 		it('responds with a 200 status', () => {

--- a/test/integration/routes/front-end/index.test.js
+++ b/test/integration/routes/front-end/index.test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const assert = require('proclaim');
+const auth = require('../../helpers/auth');
 const database = require('../../helpers/database');
 let response;
 
@@ -10,10 +11,12 @@ describe('GET /', () => {
 		await database.seed(dashboard, 'basic');
 	});
 
-	describe('when everything is valid', () => {
+	describe('when a user is logged in', () => {
 
 		before(async () => {
-			response = await request.get('/');
+			response = await request.get('/', {
+				jar: await auth.getCookieJar('read@example.com', 'password')
+			});
 		});
 
 		it('responds with a 200 status', () => {
@@ -28,6 +31,43 @@ describe('GET /', () => {
 		it('it responds with the home page', () => {
 			const body = response.body.document.querySelector('body');
 			assert.match(body.innerHTML, /hello world/i);
+		});
+
+	});
+
+	describe('when no user is logged in', () => {
+
+		before(async () => {
+			response = await request.get('/');
+		});
+
+		it('responds with a 302 status', () => {
+			assert.strictEqual(response.statusCode, 302);
+		});
+
+		it('responds with a Location header pointing to the login page', () => {
+			assert.strictEqual(response.headers.location, '/login');
+		});
+
+		it('responds with plain text', () => {
+			assert.include(response.headers['content-type'], 'text/plain');
+		});
+
+	});
+
+	describe('when no user is logged in and the public read access setting is enabled', () => {
+
+		before(async () => {
+			await database.seed(dashboard, 'no-auth');
+			response = await request.get('/');
+		});
+
+		it('responds with a 200 status', () => {
+			assert.strictEqual(response.statusCode, 200);
+		});
+
+		it('responds with HTML', () => {
+			assert.include(response.headers['content-type'], 'text/html');
 		});
 
 	});

--- a/test/integration/seed/basic/settings.js
+++ b/test/integration/seed/basic/settings.js
@@ -7,7 +7,7 @@ exports.seed = async database => {
 	await database('settings').insert([
 		{
 			id: 'publicReadAccess',
-			value: JSON.stringify(true)
+			value: JSON.stringify(false)
 		},
 		{
 			id: 'setupComplete',

--- a/test/integration/seed/basic/sites.js
+++ b/test/integration/seed/basic/sites.js
@@ -1,0 +1,28 @@
+'use strict';
+
+// Test site details
+exports.seed = async database => {
+
+	// Insert test sites
+	await database('sites').insert([
+		{
+			id: 'mock-site-id-1',
+			name: 'Mock Site 1',
+			base_url: 'http://mock-site-1/',
+			is_runnable: true,
+			is_scheduled: true,
+			schedule: 'mock-schedule',
+			pa11y_config: JSON.stringify({})
+		},
+		{
+			id: 'mock-site-id-2',
+			name: 'Mock Site 2',
+			base_url: 'http://mock-site-2/',
+			is_runnable: true,
+			is_scheduled: true,
+			schedule: 'mock-schedule',
+			pa11y_config: JSON.stringify({})
+		}
+	]);
+
+};

--- a/test/integration/seed/no-auth/sites.js
+++ b/test/integration/seed/no-auth/sites.js
@@ -1,0 +1,28 @@
+'use strict';
+
+// Test site details
+exports.seed = async database => {
+
+	// Insert test sites
+	await database('sites').insert([
+		{
+			id: 'mock-site-id-1',
+			name: 'Mock Site 1',
+			base_url: 'http://mock-site-1/',
+			is_runnable: true,
+			is_scheduled: true,
+			schedule: 'mock-schedule',
+			pa11y_config: JSON.stringify({})
+		},
+		{
+			id: 'mock-site-id-2',
+			name: 'Mock Site 2',
+			base_url: 'http://mock-site-2/',
+			is_runnable: true,
+			is_scheduled: true,
+			schedule: 'mock-schedule',
+			pa11y_config: JSON.stringify({})
+		}
+	]);
+
+};

--- a/test/unit/lib/dashboard.test.js
+++ b/test/unit/lib/dashboard.test.js
@@ -18,6 +18,7 @@ describe('lib/dashboard', () => {
 	let initFrontEndController;
 	let initKeyModel;
 	let initSettingModel;
+	let initSiteModel;
 	let initUserModel;
 	let knex;
 	let log;
@@ -59,6 +60,9 @@ describe('lib/dashboard', () => {
 
 		initSettingModel = sinon.stub().returns(require('../mock/model/setting.mock'));
 		mockery.registerMock('../model/setting', initSettingModel);
+
+		initSiteModel = sinon.stub().returns(require('../mock/model/site.mock'));
+		mockery.registerMock('../model/site', initSiteModel);
 
 		initUserModel = sinon.stub().returns(require('../mock/model/user.mock'));
 		mockery.registerMock('../model/user', initUserModel);
@@ -135,6 +139,8 @@ describe('lib/dashboard', () => {
 			assert.calledWithExactly(initKeyModel, dashboard);
 			assert.calledOnce(initSettingModel);
 			assert.calledWithExactly(initSettingModel, dashboard);
+			assert.calledOnce(initSiteModel);
+			assert.calledWithExactly(initSiteModel, dashboard);
 			assert.calledOnce(initUserModel);
 			assert.calledWithExactly(initUserModel, dashboard);
 		});
@@ -143,6 +149,7 @@ describe('lib/dashboard', () => {
 			assert.isObject(dashboard.model);
 			assert.strictEqual(dashboard.model.Key, initKeyModel.firstCall.returnValue);
 			assert.strictEqual(dashboard.model.Setting, initSettingModel.firstCall.returnValue);
+			assert.strictEqual(dashboard.model.Site, initSiteModel.firstCall.returnValue);
 			assert.strictEqual(dashboard.model.User, initUserModel.firstCall.returnValue);
 		});
 

--- a/test/unit/mock/model/site.mock.js
+++ b/test/unit/mock/model/site.mock.js
@@ -1,0 +1,5 @@
+'use strict';
+
+const sinon = require('sinon');
+
+module.exports = sinon.stub();

--- a/view/partial/form/site.dust
+++ b/view/partial/form/site.dust
@@ -1,0 +1,62 @@
+
+<form data-test="site-form" action="{action}" method="post" enctype="application/x-www-form-urlencoded">
+
+	{>"partial/alert/success" success=form.site.success/}
+	{>"partial/alert/error" errors=form.site.errors/}
+
+	<div class="field field--text">
+		<label for="site-name">
+			Name
+			<span class="field__sublabel">
+				A human-readable name for the site, this appears across the interface
+			</span>
+		</label>
+		<input id="site-name" type="text" name="name" value="{form.site.name}" required/>
+	</div>
+
+	<div class="field field--text">
+		<label for="site-base-url">
+			Base URL
+			<span class="field__sublabel">
+				The base URL for the site, which is prepended to each URL
+			</span>
+		</label>
+		<input id="site-base-url" type="url" name="baseUrl" value="{form.site.baseUrl}" required/>
+	</div>
+
+	<div class="field field--checkbox">
+		<label for="site-is-runnable">
+			Runnable
+			<span class="field__sublabel">
+				<input id="site-is-runnable" type="checkbox" name="isRunnable" {?form.site.isRunnable}checked{/form.site.isRunnable}/>
+				Whether tests can be run for this site through the Sidekick interface.
+				Do not enable this if you only wish to push data into Sidekick via an API
+			</span>
+		</label>
+	</div>
+
+	<div class="field field--checkbox">
+		<label for="site-is-scheduled">
+			Schedule
+			<span class="field__sublabel">
+				<input id="site-is-scheduled" type="checkbox" name="isScheduled" {?form.site.isScheduled}checked{/form.site.isScheduled}/>
+				Whether tests should be run on a schedule
+			</span>
+		</label>
+	</div>
+
+	<div class="field field--text">
+		<label for="site-schedule">
+			Schedule frequency
+			<span class="field__sublabel">
+				TODO we haven't decided what format this data takes yet, possibly a crontab
+			</span>
+		</label>
+		<input id="site-schedule" type="text" name="schedule" value="{form.site.schedule}"/>
+	</div>
+
+	<div class="field">
+		<input type="submit" value="{cta}" class="button button--submit"/>
+	</div>
+
+</form>

--- a/view/partial/nav/api-docs.dust
+++ b/view/partial/nav/api-docs.dust
@@ -12,6 +12,11 @@
 			</a>
 		</li>
 		<li>
+			<a href="/docs/api/v1/sites" class="navigation__item {@currentUrl test="/docs/api/v1/sites"}navigation__item--current{/currentUrl}">
+				Sites
+			</a>
+		</li>
+		<li>
 			<a href="/docs/api/v1/users" class="navigation__item {@currentUrl test="/docs/api/v1/users"}navigation__item--current{/currentUrl}">
 				Users
 			</a>

--- a/view/partial/nav/main.dust
+++ b/view/partial/nav/main.dust
@@ -6,9 +6,16 @@
 				Pa11y Sidekick
 			</a>
 		</li>
+		{?permissions.read}
+			<li>
+				<a href="/sites" class="navigation__item {@currentUrl test="/sites*"}navigation__item--current{/currentUrl}">
+					Sites
+				</a>
+			</li>
+		{/permissions.read}
 		{?permissions.admin}
 			<li>
-				<a href="/admin" class="navigation__item {@currentUrl test="/admin/*"}navigation__item--current{/currentUrl}">
+				<a href="/admin" class="navigation__item {@currentUrl test="/admin*"}navigation__item--current{/currentUrl}">
 					Admin
 				</a>
 			</li>

--- a/view/template/docs/api-v1-sites.dust
+++ b/view/template/docs/api-v1-sites.dust
@@ -1,0 +1,545 @@
+{>"layout/full"/}
+
+{<title}
+	Sites and URLs - API Documentation - Sidekick
+{/title}
+
+{<secondary-nav}
+	{>"partial/nav/api-docs"/}
+{/secondary-nav}
+
+{<content}
+
+	<h1>Sites and URLs</h1>
+
+	<p>
+		These endpoints are all used to create and manage sites and their URLs. Many of these
+		require the <a href="/docs/api/v1#permissions"><code>READ</code>, <code>WRITE</code>, or <code>DELETE</code> permissions</a>,
+		and some of them require you to send <a href="/docs/api/v1#authentication">authentication headers</a>.
+	</p>
+
+	<ol class="table-of-contents">
+		<li><a href="#resource-site">Resource type: Site</a></li>
+		<li><a href="#get-api-v1-sites">Endpoint: List all sites</a></li>
+		<li><a href="#post-api-v1-sites">Endpoint: Create a new site</a></li>
+		<li><a href="#get-api-v1-sites-(id)">Endpoint: Get a site</a></li>
+		<li><a href="#patch-api-v1-sites-(id)">Endpoint: Edit a site</a></li>
+		<li><a href="#delete-api-v1-sites-(id)">Endpoint: Delete a site</a></li>
+	</ol>
+
+
+	<h2 id="resource-site">Site resources</h2>
+
+	<p>
+		Endpoints which deal with sites mostly respond with Site resources.
+		When represented as JSON, Sites always follow this schema:
+	</p>
+
+	{@codeBlock language="json"}
+		{
+			// The site's unique ID
+			"id": "xxxxxx",
+
+			// The site name
+			"name": "Example Site",
+
+			// The site's base URL (prepended to every other URL)
+			"baseUrl": "https://example.com/",
+
+			// Whether tests can be run for this site through the Sidekick interface
+			"isRunnable": true,
+
+			// Whether tests for this site run at a scheduled interval
+			"isScheduled": true,
+
+			// The schedule that the tests run on for this site
+			"schedule": "...",
+
+			// The defauly Pa11y configuration for URLs under this site
+			"pa11yConfig": {
+				// ...
+			{~rb},
+
+			// Meta information about the site
+			"meta": {
+				"dateCreated": "2018-01-01T00:00:00.000Z",
+				"dateUpdated": "2018-01-01T00:00:00.000Z"
+			}
+		}
+	{/codeBlock}
+
+
+	<h2 id="get-api-v1-sites">List all sites</h2>
+
+	<p>
+		List all sites in the application.
+	</p>
+
+	<ul>
+		{?publicReadAccess}
+			<li>This endpoint can be accessed withput authentication</li>
+		{:else}
+			<li>This endpoint <a href="/docs/api/v1#authentication">requires authentication</a></li>
+		{/publicReadAccess}
+		<li>This endpoint requires the authenticated user to have the <a href="/docs/api/v1#permissions"><code>READ</code> permission</a></li>
+	</ul>
+
+	<h3>Request</h3>
+
+	<div class="table-wrapper">
+		<table class="table table--striped">
+			<tbody>
+				<tr>
+					<th scope="row">Method</th>
+					<td><code>GET</code></td>
+				</tr>
+				<tr>
+					<th scope="row">Path</th>
+					<td>
+						<code>/api/v1/sites</code>
+					</td>
+				</tr>
+				<tr>
+					<th scope="row">Headers</th>
+					<td>
+						<dl>
+							<dt>Content-Type</dt>
+							<dd><code>application/json</code></dd>
+						</dl>
+					</td>
+				</tr>
+			</tbody>
+		</table>
+	</div>
+
+	<h3>Response</h3>
+
+	<div class="table-wrapper">
+		<table class="table table--striped">
+			<tbody>
+				<tr>
+					<th scope="row">Status</th>
+					<td>
+						<code>200</code> on success,<br/>
+						<code>401</code> if authentication failed,<br/>
+						<code>403</code> if permission requirements are not met
+					</td>
+				</tr>
+				<tr>
+					<th scope="row">Headers</th>
+					<td>
+						<dl>
+							<dt>Content-Type</dt>
+							<dd><code>application/json</code></dd>
+						</dl>
+					</td>
+				</tr>
+				<tr>
+					<th scope="row">Body</th>
+					<td>
+						An array of <a href="#resource-site">Site resources</a>
+					</td>
+				</tr>
+			</tbody>
+		</table>
+	</div>
+
+	<h3>Example</h3>
+
+	{@codeBlock language="bash"}
+		curl -X GET \
+		     -H 'Content-Type: application/json' \
+		     -H 'X-Api-Key: xxx-xxxx-xxx' \
+		     -H 'X-Api-Secret: xxx-xxxx-xxx' \
+		     {appUrl}/api/v1/sites
+	{/codeBlock}
+
+
+	<h2 id="post-api-v1-sites">Create a new site</h2>
+
+	<p>
+		Create a new site.
+	</p>
+
+	<ul>
+		<li>This endpoint <a href="/docs/api/v1#authentication">requires authentication</a></li>
+		<li>This endpoint requires the authenticated user to have the <a href="/docs/api/v1#permissions"><code>WRITE</code> permission</a></li>
+	</ul>
+
+	<h3>Request</h3>
+
+	<div class="table-wrapper">
+		<table class="table table--striped">
+			<tbody>
+				<tr>
+					<th scope="row">Method</th>
+					<td><code>POST</code></td>
+				</tr>
+				<tr>
+					<th scope="row">Path</th>
+					<td>
+						<code>/api/v1/sites</code>
+					</td>
+				</tr>
+				<tr>
+					<th scope="row">Headers</th>
+					<td>
+						<dl>
+							<dt>Content-Type</dt>
+							<dd><code>application/json</code></dd>
+						</dl>
+					</td>
+				</tr>
+				<tr>
+					<th scope="row">Body</th>
+					<td>
+						{@codeBlock}
+							{
+								// The site's name (required)
+								"name": "Example Site",
+
+								// The site's base URL (required)
+								"baseUrl": "https://example.com/",
+
+								// Whether the site is runnable (optional)
+								isRunnable: true,
+
+								// Whether the site is run on a schedule (optional)
+								isScheduled: false,
+
+								// The site's running schedule (optional)
+								schedule: null,
+
+								// The site's Pa11y configuration (optional)
+								pa11yConfig: {}
+							}
+						{/codeBlock}
+					</td>
+				</tr>
+			</tbody>
+		</table>
+	</div>
+
+	<h3>Response</h3>
+
+	<div class="table-wrapper">
+		<table class="table table--striped">
+			<tbody>
+				<tr>
+					<th scope="row">Status</th>
+					<td>
+						<code>201</code> on success,<br/>
+						<code>400</code> if a validation error occurred,<br/>
+						<code>401</code> if authentication failed,<br/>
+						<code>403</code> if permission requirements are not met
+					</td>
+				</tr>
+				<tr>
+					<th scope="row">Headers</th>
+					<td>
+						<dl>
+							<dt>Content-Type</dt>
+							<dd><code>application/json</code></dd>
+						</dl>
+					</td>
+				</tr>
+				<tr>
+					<th scope="row">Body</th>
+					<td>
+						The newly created <a href="#resource-site">Site resources</a>
+					</td>
+				</tr>
+			</tbody>
+		</table>
+	</div>
+
+	<h3>Example</h3>
+
+	{@codeBlock language="bash"}
+		curl -X POST \
+		     -H 'Content-Type: application/json' \
+		     -H 'X-Api-Key: xxx-xxxx-xxx' \
+		     -H 'X-Api-Secret: xxx-xxxx-xxx' \
+		     -d '{"name": "Example Site", "baseUrl": "https://example.com/"}' \
+		     {appUrl}/api/v1/sites
+	{/codeBlock}
+
+
+	<h2 id="get-api-v1-sites-(id)">Get a site</h2>
+
+	<p>
+		Get a single site by ID.
+	</p>
+
+	<ul>
+		{?publicReadAccess}
+			<li>This endpoint can be accessed withput authentication</li>
+		{:else}
+			<li>This endpoint <a href="/docs/api/v1#authentication">requires authentication</a></li>
+		{/publicReadAccess}
+		<li>This endpoint requires the authenticated user to have the <a href="/docs/api/v1#permissions"><code>READ</code> permission</a></li>
+	</ul>
+
+	<h3>Request</h3>
+
+	<div class="table-wrapper">
+		<table class="table table--striped">
+			<tbody>
+				<tr>
+					<th scope="row">Method</th>
+					<td><code>GET</code></td>
+				</tr>
+				<tr>
+					<th scope="row">Path</th>
+					<td>
+						<code>/api/v1/sites/<var>:siteId</var></code>
+					</td>
+				</tr>
+				<tr>
+					<th scope="row">Headers</th>
+					<td>
+						<dl>
+							<dt>Content-Type</dt>
+							<dd><code>application/json</code></dd>
+						</dl>
+					</td>
+				</tr>
+			</tbody>
+		</table>
+	</div>
+
+	<h3>Response</h3>
+
+	<div class="table-wrapper">
+		<table class="table table--striped">
+			<tbody>
+				<tr>
+					<th scope="row">Status</th>
+					<td>
+						<code>200</code> on success,<br/>
+						<code>401</code> if authentication failed,<br/>
+						<code>403</code> if permission requirements are not met,<br/>
+						<code>404</code> if the requested site does not exist
+					</td>
+				</tr>
+				<tr>
+					<th scope="row">Headers</th>
+					<td>
+						<dl>
+							<dt>Content-Type</dt>
+							<dd><code>application/json</code></dd>
+						</dl>
+					</td>
+				</tr>
+				<tr>
+					<th scope="row">Body</th>
+					<td>
+						A <a href="#resource-site">Site resource</a>
+					</td>
+				</tr>
+			</tbody>
+		</table>
+	</div>
+
+	<h3>Example</h3>
+
+	{@codeBlock language="bash"}
+		curl -X GET \
+		     -H 'Content-Type: application/json' \
+		     -H 'X-Api-Key: xxx-xxxx-xxx' \
+		     -H 'X-Api-Secret: xxx-xxxx-xxx' \
+		     {appUrl}/api/v1/sites/xxxxxx
+	{/codeBlock}
+
+
+	<h2 id="patch-api-v1-sites-(id)">Edit a site</h2>
+
+	<p>
+		Edit a single site by ID.
+	</p>
+
+	<ul>
+		<li>This endpoint <a href="/docs/api/v1#authentication">requires authentication</a></li>
+		<li>This endpoint requires the authenticated user to have the <a href="/docs/api/v1#permissions"><code>WRITE</code> permission</a></li>
+	</ul>
+
+	<h3>Request</h3>
+
+	<div class="table-wrapper">
+		<table class="table table--striped">
+			<tbody>
+				<tr>
+					<th scope="row">Method</th>
+					<td><code>PATCH</code></td>
+				</tr>
+				<tr>
+					<th scope="row">Path</th>
+					<td>
+						<code>/api/v1/sites/<var>:siteId</var></code>
+					</td>
+				</tr>
+				<tr>
+					<th scope="row">Headers</th>
+					<td>
+						<dl>
+							<dt>Content-Type</dt>
+							<dd><code>application/json</code></dd>
+						</dl>
+					</td>
+				</tr>
+				<tr>
+					<th scope="row">Body</th>
+					<td>
+						{@codeBlock}
+							{
+								// The site's name (optional)
+								"name": "Example Site",
+
+								// The site's base URL (optional)
+								"baseUrl": "https://example.com/",
+
+								// Whether the site is runnable (optional)
+								isRunnable: true,
+
+								// Whether the site is run on a schedule (optional)
+								isScheduled: false,
+
+								// The site's running schedule (optional)
+								schedule: null,
+
+								// The site's Pa11y configuration (optional)
+								pa11yConfig: {}
+							}
+						{/codeBlock}
+					</td>
+				</tr>
+			</tbody>
+		</table>
+	</div>
+
+	<h3>Response</h3>
+
+	<div class="table-wrapper">
+		<table class="table table--striped">
+			<tbody>
+				<tr>
+					<th scope="row">Status</th>
+					<td>
+						<code>200</code> on success,<br/>
+						<code>400</code> if a validation error occurred,<br/>
+						<code>401</code> if authentication failed,<br/>
+						<code>403</code> if permission requirements are not met,<br/>
+						<code>404</code> if the requested site does not exist
+					</td>
+				</tr>
+				<tr>
+					<th scope="row">Headers</th>
+					<td>
+						<dl>
+							<dt>Content-Type</dt>
+							<dd><code>application/json</code></dd>
+						</dl>
+					</td>
+				</tr>
+				<tr>
+					<th scope="row">Body</th>
+					<td>
+						The updated <a href="#resource-site">Site resource</a>
+					</td>
+				</tr>
+			</tbody>
+		</table>
+	</div>
+
+	{@codeBlock language="bash"}
+		curl -X PATCH \
+		     -H 'Content-Type: application/json' \
+		     -H 'X-Api-Key: xxx-xxxx-xxx' \
+		     -H 'X-Api-Secret: xxx-xxxx-xxx' \
+		     -d '{"name": "Example Site", "baseUrl": "https://example.com/"}' \
+		     {appUrl}/api/v1/sites/xxxxxx
+	{/codeBlock}
+
+
+	<h2 id="delete-api-v1-sites-(id)">Delete a site</h2>
+
+	<p>
+		Delete a single site by ID.
+	</p>
+
+	<ul>
+		<li>This endpoint <a href="/docs/api/v1#authentication">requires authentication</a></li>
+		<li>This endpoint requires the authenticated user to have the <a href="/docs/api/v1#permissions"><code>DELETE</code> permission</a></li>
+	</ul>
+
+	<h3>Request</h3>
+
+	<div class="table-wrapper">
+		<table class="table table--striped">
+			<tbody>
+				<tr>
+					<th scope="row">Method</th>
+					<td><code>DELETE</code></td>
+				</tr>
+				<tr>
+					<th scope="row">Path</th>
+					<td>
+						<code>/api/v1/sites/<var>:siteId</var></code>
+					</td>
+				</tr>
+				<tr>
+					<th scope="row">Headers</th>
+					<td>
+						<dl>
+							<dt>Content-Type</dt>
+							<dd><code>application/json</code></dd>
+						</dl>
+					</td>
+				</tr>
+			</tbody>
+		</table>
+	</div>
+
+	<h3>Response</h3>
+
+	<div class="table-wrapper">
+		<table class="table table--striped">
+			<tbody>
+				<tr>
+					<th scope="row">Status</th>
+					<td>
+						<code>204</code> on success,<br/>
+						<code>401</code> if authentication failed,<br/>
+						<code>403</code> if permission requirements are not met,<br/>
+						<code>404</code> if the requested site does not exist
+					</td>
+				</tr>
+				<tr>
+					<th scope="row">Headers</th>
+					<td>
+						<dl>
+							<dt>Content-Type</dt>
+							<dd><code>application/json</code></dd>
+						</dl>
+					</td>
+				</tr>
+				<tr>
+					<th scope="row">Body</th>
+					<td>An empty object</td>
+				</tr>
+			</tbody>
+		</table>
+	</div>
+
+	<h3>Example</h3>
+
+	{@codeBlock language="bash"}
+		curl -X DELETE \
+		     -H 'Content-Type: application/json' \
+		     -H 'X-Api-Key: xxx-xxxx-xxx' \
+		     -H 'X-Api-Secret: xxx-xxxx-xxx' \
+		     {appUrl}/api/v1/sites/xxxxxx
+	{/codeBlock}
+
+
+{/content}

--- a/view/template/sites/new-site.dust
+++ b/view/template/sites/new-site.dust
@@ -1,0 +1,13 @@
+{>"layout/full"/}
+
+{<title}
+	Creating Site - Sidekick
+{/title}
+
+{<content}
+
+	<h1>Create a new site</h1>
+
+	{>"partial/form/site" action=requestPath cta="Create site"/}
+
+{/content}

--- a/view/template/sites/site.dust
+++ b/view/template/sites/site.dust
@@ -1,0 +1,30 @@
+{>"layout/full"/}
+
+{<title}
+	{site.name} - Sites - Sidekick
+{/title}
+
+{<content}
+
+	{?form.site.created}
+		<div class="alert alert--success">
+			<p data-test="site-new">
+				The site "{form.site.created.name}" has been created.
+			</p>
+		</div>
+	{/form.site.created}
+
+	<div class="heading-wrapper">
+		<h1>{site.name}</h1>
+	</div>
+
+	<dl>
+		<dt>Base URL</dt>
+		<dd><a href="{site.baseUrl}">{site.baseUrl}</a></dd>
+		<dt>Runnable</dt>
+		<dd>{?site.isRunnable}Yes{:else}No{/site.isRunnable}</a></dd>
+		<dt>Scheduled</dt>
+		<dd>{?site.isScheduled}Yes{:else}No{/site.isScheduled}</a></dd>
+	</dl>
+
+{/content}

--- a/view/template/sites/sites.dust
+++ b/view/template/sites/sites.dust
@@ -1,0 +1,32 @@
+{>"layout/full"/}
+
+{<title}
+	Sites - Sidekick
+{/title}
+
+{<content}
+
+	<div class="heading-wrapper">
+		<h1>Sites</h1>
+		{?permissions.write}
+			<a href="/sites/new" class="button">Create a new site</a>
+		{/permissions.write}
+	</div>
+
+	{?sites}
+		<ul class="sites">
+			{#sites}
+				<li>
+					<h3><a href="/sites/{id}">{name}</a></h3>
+				</li>
+			{/sites}
+		</ul>
+	{:else}
+		<p>
+			You don't have any sites yet.
+			{?permissions.write}
+				You can <a href="/sites/new">create one here</a>.</p>
+			{/permissions.write}
+	{/sites}
+
+{/content}


### PR DESCRIPTION
You can now create, list, view, edit, and delete sites through the API.
You can create, list, and view through the interface. I'm going to do
some cleanup of the API routes before continuing on with this work.

I'm going to test this and then merge, just so I can continue on.
Sorry – once we get the bulk of this stuff in place then I'll observe
our process better, I'm just really on one. Integration tests are
covering most things fairly well at the moment.